### PR TITLE
Fix m1 compiler errors

### DIFF
--- a/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
@@ -721,7 +721,7 @@ namespace tree{
         assert(child_visit_count.size()==child_prior.size());
 
         std::vector<float> completed_qvalues = qtransform_completed_by_mix_value(root, child_visit_count, child_prior, discount_factor);
-        std::vector<std::vector<int>> visit_table = get_table_of_considered_visits(max_num_considered_actions, num_simulations);
+        std::vector<std::vector<int> > visit_table = get_table_of_considered_visits(max_num_considered_actions, num_simulations);
         
         int num_valid_actions = root->legal_actions.size();
         int num_considered = std::min(max_num_considered_actions, num_simulations);
@@ -1076,7 +1076,7 @@ namespace tree{
         return visit_seq_slice;
     }
 
-    std::vector<std::vector<int>> get_table_of_considered_visits(int max_num_considered_actions, int num_simulations)
+    std::vector<std::vector<int> > get_table_of_considered_visits(int max_num_considered_actions, int num_simulations)
     {
         /*
         Overview:
@@ -1087,7 +1087,7 @@ namespace tree{
         Outputs:
             - the table of considered visits.
         */
-        std::vector<std::vector<int>> table;
+        std::vector<std::vector<int> > table;
         for (int m=0;m < max_num_considered_actions+1;m++){
             table.push_back(get_sequence_of_considered_visits(m, num_simulations));
         }
@@ -1142,7 +1142,7 @@ namespace tree{
         Outputs:
             - gumbel vectors.
         */
-        std::mt19937 gen{gumbel_rng};
+        std::mt19937 gen;{gumbel_rng};
         std::extreme_value_distribution<float> d(0, 1);
 
         std::vector<float> gumbel;

--- a/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
@@ -1142,7 +1142,7 @@ namespace tree{
         Outputs:
             - gumbel vectors.
         */
-        std::mt19937 gen;{gumbel_rng};
+        std::mt19937 gen(gumbel_rng);
         std::extreme_value_distribution<float> d(0, 1);
 
         std::vector<float> gumbel;

--- a/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.h
+++ b/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.h
@@ -101,7 +101,7 @@ namespace tree {
         std::vector<float> & child_prior, float discount= 0.99, float maxvisit_init = 50.0, float value_scale = 0.1, \
         bool rescale_values = true, float epsilon = 1e-8);
     std::vector<int> get_sequence_of_considered_visits(int max_num_considered_actions, int num_simulations);
-    std::vector<std::vector<int>> get_table_of_considered_visits(int max_num_considered_actions, int num_simulations);
+    std::vector<std::vector<int> > get_table_of_considered_visits(int max_num_considered_actions, int num_simulations);
     std::vector<float> score_considered(int considered_visit, std::vector<float> gumbel, std::vector<float> logits, std::vector<float> normalized_qvalues, std::vector<int> visit_counts);
     std::vector<float> generate_gumbel(float gumbel_scale, float gumbel_rng, int shape);
 }

--- a/lzero/mcts/ctree/ctree_sampled_efficientzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_sampled_efficientzero/lib/cnode.cpp
@@ -381,7 +381,7 @@ namespace tree
             for (size_t iter = 0; iter < disturbed_probs.size(); iter++)
             {
                 #ifdef __APPLE__
-                    disc_action_with_probs.__emplace_back(std::make_pair(iter, disturbed_probs[iter]));
+                    disc_action_with_probs.emplace_back(std::make_pair(iter, disturbed_probs[iter]));
                 #else
                     disc_action_with_probs.emplace_back(std::make_pair(iter, disturbed_probs[iter]));
                 #endif


### PR DESCRIPTION
Hey y'all -- I was trying to install LightZero in a fresh venv on my m1 macbook pro.

Got a bunch of clang errors. My clang version was:
>Apple clang version 14.0.3 (clang-1403.0.22.14.1) 
> Target: arm64-apple-darwin22.5.0

So, I let the compiler guide me, and bug-fixed until the project built. Would love another set of eyes on this -- i'm not particularly good at cpp.