### PR TITLE
feature(pu): add lightzero mujoco env and related sampled efficientzero configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,15 @@ The environments and algorithms currently supported by LightZero are shown in th
 
 | Env./Alg.      | AlphaZero | MuZero | EfficientZero | Sampled EfficientZero | Gumbel MuZero |
 | ------------- | --------- | ------ | ------------- | --------------------- | ------------- |
-| Atari         | ---       | ✔    | ✔           | ✔                   | ✔             |
-| tictactoe     | ✔       | ✔    | 🔒          | 🔒                  | ✔             |
-| gomoku        | ✔       | ✔    | 🔒          | 🔒                  | ✔             |
-| go            | 🔒       | 🔒   | 🔒          | 🔒                  | 🔒             |
-| lunarlander | ---       | ✔    | ✔           | ✔                   | ✔             |
-| bipedalwalker   | ---       | ✔    | ✔           | ✔                   | 🔒             |
-| cartpole     | ---       | ✔    | ✔           | ✔                   | ✔             |
-| pendulum      | ---       | ✔    | ✔           | ✔                   | ✔             |
+| Atari         | ---       | ✔      | ✔       | ✔                   | ✔            |
+| TicTacToe     | ✔       | ✔      | 🔒      | 🔒                  | ✔            |
+| Gomoku        | ✔       | ✔      | 🔒      | 🔒                  | ✔            |
+| Go            | 🔒       | 🔒     | 🔒      | 🔒                  | 🔒            |
+| LunarLander   | ---       | ✔      | ✔       | ✔                   | ✔            |
+| BipedalWalker | ---       | ✔      | ✔       | ✔                   | 🔒            |
+| CartPole      | ---       | ✔      | ✔       | ✔                   | ✔            |
+| Pendulum      | ---       | ✔      | ✔       | ✔                   | ✔            |
+| MuJoCo        | ---       | 🔒     | 🔒      | ✔                   | 🔒            |
 
 <sup>(1): "✔" means that the corresponding item is finished and well-tested.</sup>
 
@@ -181,13 +182,18 @@ Below are the benchmark results of [MuZero](https://github.com/opendilab/LightZe
 </p>
 
 
-Below are the benchmark results of [Sampled EfficientZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/sampled_efficientzero.py) with ``Factored/Gaussian`` policy representation on three continuous action space games: [Pendulum-v1](https://github.com/opendilab/LightZero/blob/main/zoo/classic_control/pendulum/envs/pendulum_lightzero_env.py), [LunarLanderContinuous-v2](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/lunarlander/envs/lunarlander_env.py), [BipedalWalker-v3](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/bipedalwalker/envs/bipedalwalker_env.py).
-> Where ``Factored Policy`` indicates that the agent learns a policy network that outputs a categorical distribution, the dimensions of the action space for the three environments are 11, 49 (7^2), and 256 (4^4), respectively, after manual discretization. On the other hand, ``Gaussian Policy`` indicates that the agent learns a policy network that outputs parameters (mu and sigma) for a Gaussian distribution.
+Below are the benchmark results of [Sampled EfficientZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/sampled_efficientzero.py) with ``Factored/Gaussian`` policy representation on three classic continuous action space games: [Pendulum-v1](https://github.com/opendilab/LightZero/blob/main/zoo/classic_control/pendulum/envs/pendulum_lightzero_env.py), [LunarLanderContinuous-v2](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/lunarlander/envs/lunarlander_env.py), [BipedalWalker-v3](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/bipedalwalker/envs/bipedalwalker_env.py)
+and two MuJoCo continuous action space games: [Hopper-v3](https://github.com/opendilab/LightZero/blob/main/zoo/mujoco/envs/mujoco_lightzero_env.py), [Walker2d-v3](https://github.com/opendilab/LightZero/blob/main/zoo/mujoco/envs/mujoco_lightzero_env.py).
+> Where ``Factored Policy`` indicates that the agent learns a policy network that outputs a categorical distribution, the dimensions of the action space for the five environments are 11, 49 (7^2), 256 (4^4), 64 (4^3) and 4096 (4^6), respectively, after manual discretization. On the other hand, ``Gaussian Policy`` indicates that the agent learns a policy network that outputs parameters (mu and sigma) for a Gaussian distribution.
 <p align="center">
-  <img src="assets/benchmark/main/pendulum_main.png" alt="Image Description 1" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/ablation/pendulum_sez_K.png" alt="Image Description 2" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/main/lunarlander_main.png" alt="Image Description 3" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/main/bipedalwalker_main.png" alt="Image Description 3" width="23%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/pendulum_main.png" alt="Image Description 1" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/ablation/pendulum_sez_K.png" alt="Image Description 2" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/lunarlander_main.png" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
+</p>
+<p align="center">
+  <img src="assets/benchmark/main/bipedalwalker_main.png" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/hopper_main.pdf" alt="Image Description 1" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/walker2d_main.pdf" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
 </p>
 
 Below are the benchmark results of [AlphaZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/alphazero.py) and [MuZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/muzero.py) on two board_games: [TicTacToe](https://github.com/opendilab/LightZero/blob/main/zoo/board_games/tictactoe/envs/tictactoe_env.py), [Gomoku](https://github.com/opendilab/LightZero/blob/main/zoo/board_games/gomoku/envs/gomoku_env.py).

--- a/README.zh.md
+++ b/README.zh.md
@@ -76,16 +76,17 @@ LightZero 是基于 [PyTorch](https://pytorch.org/) 实现的 MCTS 算法库，�
 
 LightZero 目前支持的环境及算法如下表所示：
 
-| Env./Alg.      | AlphaZero | MuZero | EfficientZero | Sampled EfficientZero | Gumbel MuZero |
-| ------------- | --------- | ------ | ------------- | --------------------- | ------------- |
-| Atari         | ---       | ✔    | ✔           | ✔                   | ✔             |
-| tictactoe     | ✔       | ✔    | 🔒          | 🔒                  | ✔             |
-| gomoku        | ✔       | ✔    | 🔒          | 🔒                  | ✔             |
-| go            | 🔒       | 🔒   | 🔒          | 🔒                  | 🔒             |
-| lunarlander | ---       | ✔    | ✔           | ✔                   | ✔             |
-| bipedalwalker   | ---       | ✔    | ✔           | ✔                   | 🔒             |
-| cartpole     | ---       | ✔    | ✔           | ✔                   | ✔             |
-| pendulum      | ---       | ✔    | ✔           | ✔                   | ✔             |
+| Env./Alg.     | AlphaZero | MuZero | EfficientZero | Sampled EfficientZero | Gumbel MuZero |
+|---------------| --------- |--------| ------- | --------------------- | ------------ |
+| Atari         | ---       | ✔      | ✔       | ✔                   | ✔            |
+| TicTacToe     | ✔       | ✔      | 🔒      | 🔒                  | ✔            |
+| Gomoku        | ✔       | ✔      | 🔒      | 🔒                  | ✔            |
+| Go            | 🔒       | 🔒     | 🔒      | 🔒                  | 🔒            |
+| LunarLander   | ---       | ✔      | ✔       | ✔                   | ✔            |
+| BipedalWalker | ---       | ✔      | ✔       | ✔                   | 🔒            |
+| CartPole      | ---       | ✔      | ✔       | ✔                   | ✔            |
+| Pendulum      | ---       | ✔      | ✔       | ✔                   | ✔            |
+| MuJoCo        | ---       | 🔒     | 🔒      | ✔                   | 🔒            |
 
 
 <sup>(1): "✔" 表示对应的项目已经完成并经过良好的测试。</sup>
@@ -140,14 +141,19 @@ python3 -u zoo/board_games/tictactoe/config/tictactoe_muzero_bot_mode_config.py
   <img src="assets/benchmark/ablation/mspacman_sez_K.png" alt="Image Description 4" width="23%" height="auto" style="margin: 0 1%;">
 </p>
 
-以下是使用 ``Factored/Gaussian`` 策略表征方法的 [Sampled EfficientZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/sampled_efficientzero.py) 在三个连续动作空间上的基线效果：[Pendulum-v1](https://github.com/opendilab/LightZero/blob/main/zoo/classic_control/pendulum/envs/pendulum_lightzero_env.py)，[LunarLanderContinuous-v2](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/lunarlander/envs/lunarlander_env.py) 和 [BipedalWalker-v3](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/bipedalwalker/envs/bipedalwalker_env.py)。
-> 其中 ``Factored Policy`` 表示 agent 学习一个输出离散分布的策略网络，上述三种环境手动离散化后的动作空间维度分别为11、49（7^2）和 256（4^4)。``Gaussian Policy``表示 agent 学习一个策略网络，该网络直接输出高斯分布的参数（mu 和 sigma）。
+以下是使用 ``Factored/Gaussian`` 策略表征方法的 [Sampled EfficientZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/sampled_efficientzero.py) 在5个连续动作空间环境上的基线效果：[Pendulum-v1](https://github.com/opendilab/LightZero/blob/main/zoo/classic_control/pendulum/envs/pendulum_lightzero_env.py)，[LunarLanderContinuous-v2](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/lunarlander/envs/lunarlander_env.py)，[BipedalWalker-v3](https://github.com/opendilab/LightZero/blob/main/zoo/box2d/bipedalwalker/envs/bipedalwalker_env.py)，[Hopper-v3](https://github.com/opendilab/LightZero/blob/main/zoo/mujoco/envs/mujoco_lightzero_env.py) 和 [Walker2d-v3](https://github.com/opendilab/LightZero/blob/main/zoo/mujoco/envs/mujoco_lightzero_env.py).
+> 其中 ``Factored Policy`` 表示 agent 学习一个输出离散分布的策略网络，上述三种环境手动离散化后的动作空间维度分别为11、49（7^2、256（4^4)、64 (4^3) and 4096 (4^6)。``Gaussian Policy``表示 agent 学习一个策略网络，该网络直接输出高斯分布的参数（mu 和 sigma）。
 
 <p align="center">
-  <img src="assets/benchmark/main/pendulum_main.png" alt="Image Description 1" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/ablation/pendulum_sez_K.png" alt="Image Description 2" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/main/lunarlander_main.png" alt="Image Description 3" width="23%" height="auto" style="margin: 0 1%;">
-  <img src="assets/benchmark/main/bipedalwalker_main.png" alt="Image Description 3" width="23%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/pendulum_main.png" alt="Image Description 1" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/ablation/pendulum_sez_K.png" alt="Image Description 2" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/lunarlander_main.png" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
+</p>
+
+<p align="center">
+  <img src="assets/benchmark/main/bipedalwalker_main.png" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/hopper_main.pdf" alt="Image Description 1" width="33%" height="auto" style="margin: 0 1%;">
+  <img src="assets/benchmark/main/walker2d_main.pdf" alt="Image Description 3" width="33%" height="auto" style="margin: 0 1%;">
 </p>
 
 以下是在两个棋类游戏（[TicTacToe(井字棋)](https://github.com/opendilab/LightZero/blob/main/zoo/board_games/tictactoe/envs/tictactoe_env.py) 和 [Gomoku(五子棋)](https://github.com/opendilab/LightZero/blob/main/zoo/board_games/gomoku/envs/gomoku_env.py)）上 [AlphaZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/alphazero.py) 和 [MuZero](https://github.com/opendilab/LightZero/blob/main/lzero/policy/muzero.py) 的基线效果：

--- a/lzero/policy/efficientzero.py
+++ b/lzero/policy/efficientzero.py
@@ -90,6 +90,10 @@ class EfficientZeroPolicy(Policy):
         augmentation=['shift', 'intensity'],
 
         # ******* learn ******
+        # (bool) Whether to ignore the done flag in the training data. Typically, this value is set to False.
+        # However, for some environments with a fixed episode length, to ensure the accuracy of Q-value calculations,
+        # we should set it to True to avoid the influence of the done flag.
+        ignore_done=False,
         # (int) How many updates(iterations) to train after collector's one collection.
         # Bigger "update_per_collect" means bigger off-policy.
         # collect data -> update policy-> collect data -> ...

--- a/lzero/policy/gumbel_muzero.py
+++ b/lzero/policy/gumbel_muzero.py
@@ -91,6 +91,10 @@ class GumeblMuZeroPolicy(Policy):
         augmentation=['shift', 'intensity'],
 
         # ******* learn ******
+        # (bool) Whether to ignore the done flag in the training data. Typically, this value is set to False.
+        # However, for some environments with a fixed episode length, to ensure the accuracy of Q-value calculations,
+        # we should set it to True to avoid the influence of the done flag.
+        ignore_done=False,
         # (int) How many updates(iterations) to train after collector's one collection.
         # Bigger "update_per_collect" means bigger off-policy.
         # collect data -> update policy-> collect data -> ...

--- a/lzero/policy/muzero.py
+++ b/lzero/policy/muzero.py
@@ -73,9 +73,9 @@ class MuZeroPolicy(Policy):
         collector_env_num=8,
         # (int) The number of environments used in evaluating policy.
         evaluator_env_num=3,
-        # (str) The type of environment. Options is ['not_board_games', 'board_games'].
+        # (str) The type of environment. Options are ['not_board_games', 'board_games'].
         env_type='not_board_games',
-        # (str) The type of battle mode. Options is ['play_with_bot_mode', 'self_play_mode'].
+        # (str) The type of battle mode. Options are ['play_with_bot_mode', 'self_play_mode'].
         battle_mode='play_with_bot_mode',
         # (bool) Whether to monitor extra statistics in tensorboard.
         monitor_extra_statistics=True,
@@ -91,6 +91,10 @@ class MuZeroPolicy(Policy):
         augmentation=['shift', 'intensity'],
 
         # ******* learn ******
+        # (bool) Whether to ignore the done flag in the training data. Typically, this value is set to False.
+        # However, for some environments with a fixed episode length, to ensure the accuracy of Q-value calculations,
+        # we should set it to True to avoid the influence of the done flag.
+        ignore_done=False,
         # (int) How many updates(iterations) to train after collector's one collection.
         # Bigger "update_per_collect" means bigger off-policy.
         # collect data -> update policy-> collect data -> ...

--- a/lzero/policy/sampled_efficientzero.py
+++ b/lzero/policy/sampled_efficientzero.py
@@ -96,7 +96,11 @@ class SampledEfficientZeroPolicy(Policy):
         # (list) The style of augmentation.
         augmentation=['shift', 'intensity'],
 
-        # ******* learn ******
+        # ****** learn ******
+        # (bool) Whether to ignore the done flag in the training data. Typically, this value is set to False.
+        # However, for some environments with a fixed episode length, to ensure the accuracy of Q-value calculations,
+        # we should set it to True to avoid the influence of the done flag.
+        ignore_done=False,
         # (int) How many updates(iterations) to train after collector's one collection.
         # Bigger "update_per_collect" means bigger off-policy.
         # collect data -> update policy-> collect data -> ...

--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -208,7 +208,7 @@ class MuZeroCollector(ISerialCollector):
     def pad_and_save_last_trajectory(self, i, last_game_segments, last_game_priorities, game_segments, done) -> None:
         """
         Overview:
-            put the last game block into the pool if the current game is finished
+            put the last game segment into the pool if the current game is finished
         Arguments:
             - last_game_segments (:obj:`list`): list of the last game segments
             - last_game_priorities (:obj:`list`): list of the last game priorities
@@ -216,7 +216,7 @@ class MuZeroCollector(ISerialCollector):
         Note:
             (last_game_segments[i].obs_segment[-4:][j] == game_segments[i].obs_segment[:4][j]).all() is True
         """
-        # pad over last block trajectory
+        # pad over last segment trajectory
         beg_index = self.policy_config.model.frame_stack_num
         end_index = beg_index + self.policy_config.num_unroll_steps
 
@@ -260,7 +260,7 @@ class MuZeroCollector(ISerialCollector):
 
         last_game_segments[i].game_segment_to_array()
 
-        # put the game block into the pool
+        # put the game segment into the pool
         self.game_segment_pool.append((last_game_segments[i], last_game_priorities[i], done[i]))
 
         # reset last game_segments
@@ -459,11 +459,15 @@ class MuZeroCollector(ISerialCollector):
                     )
 
                     # NOTE: the position of code snippet is very important.
-                    # the obs['action_mask'] and obs['to_play'] is corresponding to next action
+                    # the obs['action_mask'] and obs['to_play'] are corresponding to the next action
                     action_mask_dict[env_id] = to_ndarray(obs['action_mask'])
                     to_play_dict[env_id] = to_ndarray(obs['to_play'])
 
-                    dones[env_id] = done
+                    if self.policy_config.ignore_done:
+                        dones[env_id] = False
+                    else:
+                        dones[env_id] = done
+
                     visit_entropies_lst[env_id] += visit_entropy_dict[env_id]
                     if self.policy_config.gumbel_algo:
                         completed_value_lst[env_id] += np.mean(np.array(completed_value_dict[env_id]))
@@ -481,14 +485,14 @@ class MuZeroCollector(ISerialCollector):
                     observation_window_stack[env_id].append(to_ndarray(obs['observation']))
 
                     # ==============================================================
-                    # we will save a game block if it is the end of the game or the next game block is finished.
+                    # we will save a game segment if it is the end of the game or the next game segment is finished.
                     # ==============================================================
 
-                    # if game block is full, we will save the last game block
+                    # if game segment is full, we will save the last game segment
                     if game_segments[env_id].is_full():
-                        # pad over last block trajectory
+                        # pad over last segment trajectory
                         if last_game_segments[env_id] is not None:
-                            # TODO(pu): return the one game block
+                            # TODO(pu): return the one game segment
                             self.pad_and_save_last_trajectory(
                                 env_id, last_game_segments, last_game_priorities, game_segments, dones
                             )
@@ -532,24 +536,24 @@ class MuZeroCollector(ISerialCollector):
                     self._episode_info.append(info)
 
                     # ==============================================================
-                    # if it is the end of the game, we will save the game block
+                    # if it is the end of the game, we will save the game segment
                     # ==============================================================
 
-                    # NOTE: put the penultimate game block in one episode into the trajectory_pool
+                    # NOTE: put the penultimate game segment in one episode into the trajectory_pool
                     # pad over 2th last game_segment using the last game_segment
                     if last_game_segments[env_id] is not None:
                         self.pad_and_save_last_trajectory(
                             env_id, last_game_segments, last_game_priorities, game_segments, dones
                         )
 
-                    # store current block trajectory
+                    # store current segment trajectory
                     priorities = self._compute_priorities(env_id, pred_values_lst, search_values_lst)
 
-                    # NOTE: put the last game block in one episode into the trajectory_pool
+                    # NOTE: put the last game segment in one episode into the trajectory_pool
                     game_segments[env_id].game_segment_to_array()
 
                     # assert len(game_segments[env_id]) == len(priorities)
-                    # NOTE: save the last game block in one episode into the trajectory_pool if it's not null
+                    # NOTE: save the last game segment in one episode into the trajectory_pool if it's not null
                     if len(game_segments[env_id].reward_segment) != 0:
                         self.game_segment_pool.append((game_segments[env_id], priorities, dones[env_id]))
 
@@ -622,6 +626,7 @@ class MuZeroCollector(ISerialCollector):
                         'unroll_plus_td_steps': self.unroll_plus_td_steps
                     } for i in range(len(self.game_segment_pool))
                 ]
+                self.game_segment_pool.clear()
                 # for i in range(len(self.game_segment_pool)):
                 #     print(self.game_segment_pool[i][0].obs_segment.__len__())
                 #     print(self.game_segment_pool[i][0].reward_segment)

--- a/zoo/mujoco/config/mujoco_disc_sampled_efficientzero_config.py
+++ b/zoo/mujoco/config/mujoco_disc_sampled_efficientzero_config.py
@@ -1,0 +1,117 @@
+from easydict import EasyDict
+
+# options={'Hopper-v3', 'HalfCheetah-v3', 'Walker2d-v3', 'Ant-v3', 'Humanoid-v3'}
+env_name = 'Hopper-v3'
+
+if env_name == 'Hopper-v3':
+    action_space_size = 3
+    observation_shape = 11
+elif env_name in ['HalfCheetah-v3', 'Walker2d-v3']:
+    action_space_size = 6
+    observation_shape = 17
+elif env_name == 'Ant-v3':
+    action_space_size = 8
+    observation_shape = 111
+elif env_name == 'Humanoid-v3':
+    action_space_size = 17
+    observation_shape = 376
+
+ignore_done = False
+if env_name == 'HalfCheetah-v3':
+    # for halfcheetah, we ignore done signal to predict the Q value of the last step correctly.
+    ignore_done = True
+
+# ==============================================================
+# begin of the most frequently changed config specified by the user
+# ==============================================================
+collector_env_num = 8
+n_episode = 8
+evaluator_env_num = 3
+continuous_action_space = False
+K = 20  # num_of_sampled_actions
+num_simulations = 50
+update_per_collect = 200
+batch_size = 256
+max_env_step = int(3e6)
+reanalyze_ratio = 0.
+each_dim_disc_size = 5
+policy_entropy_loss_weight = 0.005
+
+
+# ==============================================================
+# end of the most frequently changed config specified by the user
+# ==============================================================
+
+mujoco_disc_sampled_efficientzero_config = dict(
+    exp_name=
+    f'data_sez_ctree/{env_name[:-3]}_bin-{each_dim_disc_size}_sampled_efficientzero_ns{num_simulations}_upc{update_per_collect}_rr{reanalyze_ratio}_bs-{batch_size}_pelw{policy_entropy_loss_weight}_seed0',
+    env=dict(
+        env_name=env_name,
+        action_clip=True,
+        continuous=False,
+        manually_discretization=False,
+        collector_env_num=collector_env_num,
+        evaluator_env_num=evaluator_env_num,
+        n_evaluator_episode=evaluator_env_num,
+        manager=dict(shared_memory=False, ),
+        each_dim_disc_size=each_dim_disc_size,
+    ),
+    policy=dict(
+        model=dict(
+            observation_shape=observation_shape,
+            action_space_size=int(each_dim_disc_size ** action_space_size),
+            continuous_action_space=continuous_action_space,
+            num_of_sampled_actions=K,
+            model_type='mlp',
+            lstm_hidden_size=256,
+            latent_state_dim=256,
+            self_supervised_learning_loss=True,
+            res_connection_in_dynamics=True,
+            norm_type='BN',
+        ),
+        mcts_ctree=True,
+        cuda=True,
+        policy_entropy_loss_weight=policy_entropy_loss_weight,
+        ignore_done=ignore_done,
+        env_type='not_board_games',
+        game_segment_length=200,
+        update_per_collect=update_per_collect,
+        batch_size=batch_size,
+        discount_factor=0.99,
+        optim_type='AdamW',
+        lr_piecewise_constant_decay=False,
+        learning_rate=0.003,
+        num_simulations=num_simulations,
+        reanalyze_ratio=reanalyze_ratio,
+        n_episode=n_episode,
+        eval_freq=int(2e3),
+        replay_buffer_size=int(1e6),
+        collector_env_num=collector_env_num,
+        evaluator_env_num=evaluator_env_num,
+    ),
+)
+
+mujoco_disc_sampled_efficientzero_config = EasyDict(mujoco_disc_sampled_efficientzero_config)
+main_config = mujoco_disc_sampled_efficientzero_config
+
+mujoco_disc_sampled_efficientzero_create_config = dict(
+    env=dict(
+        type='mujoco_disc_lightzero',
+        import_names=['zoo.mujoco.envs.mujoco_disc_lightzero_env'],
+    ),
+    env_manager=dict(type='subprocess'),
+    policy=dict(
+        type='sampled_efficientzero',
+        import_names=['lzero.policy.sampled_efficientzero'],
+    ),
+    collector=dict(
+        type='episode_muzero',
+        import_names=['lzero.worker.muzero_collector'],
+    )
+)
+mujoco_disc_sampled_efficientzero_create_config = EasyDict(mujoco_disc_sampled_efficientzero_create_config)
+create_config = mujoco_disc_sampled_efficientzero_create_config
+
+if __name__ == "__main__":
+    from lzero.entry import train_muzero
+    train_muzero([main_config, create_config], seed=0, max_env_step=max_env_step)

--- a/zoo/mujoco/config/mujoco_disc_sampled_efficientzero_config.py
+++ b/zoo/mujoco/config/mujoco_disc_sampled_efficientzero_config.py
@@ -44,7 +44,7 @@ policy_entropy_loss_weight = 0.005
 
 mujoco_disc_sampled_efficientzero_config = dict(
     exp_name=
-    f'data_sez_ctree/{env_name[:-3]}_bin-{each_dim_disc_size}_sampled_efficientzero_ns{num_simulations}_upc{update_per_collect}_rr{reanalyze_ratio}_bs-{batch_size}_pelw{policy_entropy_loss_weight}_seed0',
+    f'data_sez_ctree/{env_name[:-3]}_bin-{each_dim_disc_size}_sampled_efficientzero_ns{num_simulations}_upc{update_per_collect}_rr{reanalyze_ratio}_pelw{policy_entropy_loss_weight}_seed0',
     env=dict(
         env_name=env_name,
         action_clip=True,
@@ -67,9 +67,7 @@ mujoco_disc_sampled_efficientzero_config = dict(
             latent_state_dim=256,
             self_supervised_learning_loss=True,
             res_connection_in_dynamics=True,
-            norm_type='BN',
         ),
-        mcts_ctree=True,
         cuda=True,
         policy_entropy_loss_weight=policy_entropy_loss_weight,
         ignore_done=ignore_done,

--- a/zoo/mujoco/config/mujoco_sampled_efficientzero_config.py
+++ b/zoo/mujoco/config/mujoco_sampled_efficientzero_config.py
@@ -1,0 +1,119 @@
+from easydict import EasyDict
+
+# options={'Hopper-v3', 'HalfCheetah-v3', 'Walker2d-v3', 'Ant-v3', 'Humanoid-v3'}
+env_name = 'Hopper-v3'
+
+if env_name == 'Hopper-v3':
+    action_space_size = 3
+    observation_shape = 11
+elif env_name in ['HalfCheetah-v3', 'Walker2d-v3']:
+    action_space_size = 6
+    observation_shape = 17
+elif env_name == 'Ant-v3':
+    action_space_size = 8
+    observation_shape = 111
+elif env_name == 'Humanoid-v3':
+    action_space_size = 17
+    observation_shape = 376
+
+ignore_done = False
+if env_name == 'HalfCheetah-v3':
+    # for halfcheetah, we ignore done signal to predict the Q value of the last step correctly.
+    ignore_done = True
+
+# ==============================================================
+# begin of the most frequently changed config specified by the user
+# ==============================================================
+seed = 0
+collector_env_num = 8
+n_episode = 8
+evaluator_env_num = 3
+continuous_action_space = True
+K = 20  # num_of_sampled_actions
+num_simulations = 50
+update_per_collect = 200
+batch_size = 256
+
+max_env_step = int(5e6)
+reanalyze_ratio = 0.
+policy_entropy_loss_weight = 0.005
+
+# ==============================================================
+# end of the most frequently changed config specified by the user
+# ==============================================================
+
+mujoco_sampled_efficientzero_config = dict(
+    exp_name=
+    f'data_sez_ctree/{env_name[:-3]}_sampled_efficientzero_ns{num_simulations}_upc{update_per_collect}_rr{reanalyze_ratio}_bs-{batch_size}_pelw{policy_entropy_loss_weight}_seed{seed}',
+    env=dict(
+        env_name=env_name,
+        action_clip=True,
+        continuous=True,
+        manually_discretization=False,
+        collector_env_num=collector_env_num,
+        evaluator_env_num=evaluator_env_num,
+        n_evaluator_episode=evaluator_env_num,
+        manager=dict(shared_memory=False, ),
+    ),
+    policy=dict(
+        model=dict(
+            observation_shape=observation_shape,
+            action_space_size=action_space_size,
+            continuous_action_space=continuous_action_space,
+            num_of_sampled_actions=K,
+            model_type='mlp',
+            lstm_hidden_size=256,
+            latent_state_dim=256,
+            self_supervised_learning_loss=True,
+            res_connection_in_dynamics=True,
+            norm_type='BN',
+        ),
+        mcts_ctree=True,
+        cuda=True,
+        # NOTE: for continuous gaussian policy, we use the policy_entropy_loss as in the original Sampled MuZero paper.
+        policy_entropy_loss_weight=policy_entropy_loss_weight,
+        ignore_done=ignore_done,
+        env_type='not_board_games',
+        game_segment_length=200,
+        update_per_collect=update_per_collect,
+        batch_size=batch_size,
+        discount_factor=0.997,
+        optim_type='AdamW',
+        lr_piecewise_constant_decay=False,
+        learning_rate=0.003,
+        grad_clip_value=0.5,
+        num_simulations=num_simulations,
+        reanalyze_ratio=reanalyze_ratio,
+        n_episode=n_episode,
+        eval_freq=int(2e3),
+        replay_buffer_size=int(1e6),  # the size/capacity of replay_buffer, in the terms of transitions.
+        collector_env_num=collector_env_num,
+        evaluator_env_num=evaluator_env_num,
+    ),
+)
+
+mujoco_sampled_efficientzero_config = EasyDict(mujoco_sampled_efficientzero_config)
+main_config = mujoco_sampled_efficientzero_config
+
+mujoco_sampled_efficientzero_create_config = dict(
+    env=dict(
+        type='mujoco_lightzero',
+        import_names=['zoo.mujoco.envs.mujoco_lightzero_env'],
+    ),
+    env_manager=dict(type='subprocess'),
+    policy=dict(
+        type='sampled_efficientzero',
+        import_names=['lzero.policy.sampled_efficientzero'],
+    ),
+    collector=dict(
+        type='episode_muzero',
+        import_names=['lzero.worker.muzero_collector'],
+    )
+)
+mujoco_sampled_efficientzero_create_config = EasyDict(mujoco_sampled_efficientzero_create_config)
+create_config = mujoco_sampled_efficientzero_create_config
+
+if __name__ == "__main__":
+    from lzero.entry import train_muzero
+
+    train_muzero([main_config, create_config], seed=seed, max_env_step=max_env_step)

--- a/zoo/mujoco/config/mujoco_sampled_efficientzero_config.py
+++ b/zoo/mujoco/config/mujoco_sampled_efficientzero_config.py
@@ -66,11 +66,8 @@ mujoco_sampled_efficientzero_config = dict(
             latent_state_dim=256,
             self_supervised_learning_loss=True,
             res_connection_in_dynamics=True,
-            norm_type='BN',
         ),
-        mcts_ctree=True,
         cuda=True,
-        # NOTE: for continuous gaussian policy, we use the policy_entropy_loss as in the original Sampled MuZero paper.
         policy_entropy_loss_weight=policy_entropy_loss_weight,
         ignore_done=ignore_done,
         env_type='not_board_games',
@@ -86,7 +83,7 @@ mujoco_sampled_efficientzero_config = dict(
         reanalyze_ratio=reanalyze_ratio,
         n_episode=n_episode,
         eval_freq=int(2e3),
-        replay_buffer_size=int(1e6),  # the size/capacity of replay_buffer, in the terms of transitions.
+        replay_buffer_size=int(1e6),
         collector_env_num=collector_env_num,
         evaluator_env_num=evaluator_env_num,
     ),

--- a/zoo/mujoco/envs/mujoco_disc_lightzero_env.py
+++ b/zoo/mujoco/envs/mujoco_disc_lightzero_env.py
@@ -1,0 +1,176 @@
+import copy
+import os
+from itertools import product
+from typing import Union, List, Optional
+
+import gym
+import numpy as np
+from ding.envs import BaseEnv, BaseEnvTimestep
+from ding.envs.common import save_frames_as_gif
+from ding.torch_utils import to_ndarray
+from ding.utils import ENV_REGISTRY
+from dizoo.mujoco.envs.mujoco_wrappers import wrap_mujoco
+from easydict import EasyDict
+
+
+@ENV_REGISTRY.register('mujoco_disc_lightzero')
+class MujocoDiscEnv(BaseEnv):
+    """
+    Overview:
+        The modified Mujoco environment with manually discretized action space for LightZero's algorithms.
+        For each dimension, equally dividing the original continuous action into ``each_dim_disc_size`` bins and
+        using their Cartesian product to obtain handcrafted discrete actions.
+    """
+
+    @classmethod
+    def default_config(cls: type) -> EasyDict:
+        cfg = EasyDict(copy.deepcopy(cls.config))
+        cfg.cfg_type = cls.__name__ + 'Dict'
+        return cfg
+
+    config = dict(
+        action_clip=False,
+        delay_reward_step=0,
+        replay_path=None,
+        save_replay_gif=False,
+        replay_path_gif=None,
+        action_bins_per_branch=None,
+        norm_obs=dict(use_norm=False, ),
+        norm_reward=dict(use_norm=False, ),
+    )
+
+    def __init__(self, cfg: dict) -> None:
+        self._cfg = cfg
+        self._action_clip = cfg.action_clip
+        self._delay_reward_step = cfg.delay_reward_step
+        self._init_flag = False
+        self._replay_path = None
+        self._replay_path_gif = cfg.replay_path_gif
+        self._save_replay_gif = cfg.save_replay_gif
+
+    def reset(self) -> np.ndarray:
+        if not self._init_flag:
+            self._env = self._make_env()
+            self._env.observation_space.dtype = np.float32  # To unify the format of envs in LightZero
+            self._observation_space = self._env.observation_space
+            self._raw_action_space = self._env.action_space
+            self._reward_space = gym.spaces.Box(
+                low=self._env.reward_range[0], high=self._env.reward_range[1], shape=(1,), dtype=np.float32
+            )
+            self._init_flag = True
+        if hasattr(self, '_seed') and hasattr(self, '_dynamic_seed') and self._dynamic_seed:
+            np_seed = 100 * np.random.randint(1, 1000)
+            self._env.seed(self._seed + np_seed)
+        elif hasattr(self, '_seed'):
+            self._env.seed(self._seed)
+        if self._replay_path is not None:
+            self._env = gym.wrappers.RecordVideo(
+                self._env,
+                video_folder=self._replay_path,
+                episode_trigger=lambda episode_id: True,
+                name_prefix='rl-video-{}'.format(id(self))
+            )
+        if self._save_replay_gif:
+            self._frames = []
+        obs = self._env.reset()
+        obs = to_ndarray(obs).astype('float32')
+
+        # disc_to_cont: transform discrete action index to original continuous action
+        self.m = self._raw_action_space.shape[0]
+        self.n = self._cfg.each_dim_disc_size
+        self.K = self.n ** self.m
+        self.disc_to_cont = list(product(*[list(range(self.n)) for _ in range(self.m)]))
+        self._eval_episode_return = 0.
+        # the modified discrete action space
+        self._action_space = gym.spaces.Discrete(self.K)
+
+        action_mask = np.ones(self.K, 'int8')
+        obs = {'observation': obs, 'action_mask': action_mask, 'to_play': -1}
+
+        return obs
+
+    def close(self) -> None:
+        if self._init_flag:
+            self._env.close()
+        self._init_flag = False
+
+    def seed(self, seed: int, dynamic_seed: bool = True) -> None:
+        self._seed = seed
+        self._dynamic_seed = dynamic_seed
+        np.random.seed(self._seed)
+
+    def step(self, action: Union[np.ndarray, list]) -> BaseEnvTimestep:
+        # disc_to_cont: transform discrete action index to original continuous action
+        action = [-1 + 2 / self.n * k for k in self.disc_to_cont[int(action)]]
+        action = to_ndarray(action)
+
+        if self._save_replay_gif:
+            self._frames.append(self._env.render(mode='rgb_array'))
+        if self._action_clip:
+            action = np.clip(action, -1, 1)
+        obs, rew, done, info = self._env.step(action)
+
+        self._eval_episode_return += rew
+
+        if done:
+            if self._save_replay_gif:
+                path = os.path.join(
+                    self._replay_path_gif, '{}_episode_{}.gif'.format(self._cfg.env_name, self._save_replay_count)
+                )
+                save_frames_as_gif(self._frames, path)
+                self._save_replay_count += 1
+            info['eval_episode_return'] = self._eval_episode_return
+
+        obs = to_ndarray(obs).astype(np.float32)
+        rew = to_ndarray([rew]).astype(np.float32)
+
+        action_mask = np.ones(self._action_space.n, 'int8')
+        obs = {'observation': obs, 'action_mask': action_mask, 'to_play': -1}
+
+        return BaseEnvTimestep(obs, rew, done, info)
+
+    def _make_env(self):
+        return wrap_mujoco(
+            self._cfg.env_name,
+            norm_obs=self._cfg.get('norm_obs', None),
+            norm_reward=self._cfg.get('norm_reward', None),
+            delay_reward_step=self._delay_reward_step
+        )
+
+    def enable_save_replay(self, replay_path: Optional[str] = None) -> None:
+        if replay_path is None:
+            replay_path = './video'
+        self._replay_path = replay_path
+        self._save_replay = True
+        self._save_replay_count = 0
+
+    def random_action(self) -> np.ndarray:
+        return self.action_space.sample()
+
+    def __repr__(self) -> str:
+        return "LightZero modified Mujoco Env({}) with manually discretized action space".format(self._cfg.env_name)
+
+    @staticmethod
+    def create_collector_env_cfg(cfg: dict) -> List[dict]:
+        collector_cfg = copy.deepcopy(cfg)
+        collector_env_num = collector_cfg.pop('collector_env_num', 1)
+        return [collector_cfg for _ in range(collector_env_num)]
+
+    @staticmethod
+    def create_evaluator_env_cfg(cfg: dict) -> List[dict]:
+        evaluator_cfg = copy.deepcopy(cfg)
+        evaluator_env_num = evaluator_cfg.pop('evaluator_env_num', 1)
+        evaluator_cfg.norm_reward.use_norm = False
+        return [evaluator_cfg for _ in range(evaluator_env_num)]
+
+    @property
+    def observation_space(self) -> gym.spaces.Space:
+        return self._observation_space
+
+    @property
+    def action_space(self) -> gym.spaces.Space:
+        return self._action_space
+
+    @property
+    def reward_space(self) -> gym.spaces.Space:
+        return self._reward_space

--- a/zoo/mujoco/envs/mujoco_disc_lightzero_env.py
+++ b/zoo/mujoco/envs/mujoco_disc_lightzero_env.py
@@ -1,32 +1,24 @@
-import copy
 import os
 from itertools import product
-from typing import Union, List, Optional
+from typing import Union
 
 import gym
 import numpy as np
-from ding.envs import BaseEnv, BaseEnvTimestep
+from ding.envs import BaseEnvTimestep
 from ding.envs.common import save_frames_as_gif
 from ding.torch_utils import to_ndarray
 from ding.utils import ENV_REGISTRY
-from dizoo.mujoco.envs.mujoco_wrappers import wrap_mujoco
-from easydict import EasyDict
+from dizoo.mujoco.envs.mujoco_disc_env import MujocoDiscEnv
 
 
 @ENV_REGISTRY.register('mujoco_disc_lightzero')
-class MujocoDiscEnv(BaseEnv):
+class MujocoDiscEnvLZ(MujocoDiscEnv):
     """
     Overview:
         The modified Mujoco environment with manually discretized action space for LightZero's algorithms.
         For each dimension, equally dividing the original continuous action into ``each_dim_disc_size`` bins and
         using their Cartesian product to obtain handcrafted discrete actions.
     """
-
-    @classmethod
-    def default_config(cls: type) -> EasyDict:
-        cfg = EasyDict(copy.deepcopy(cls.config))
-        cfg.cfg_type = cls.__name__ + 'Dict'
-        return cfg
 
     config = dict(
         action_clip=False,
@@ -40,7 +32,10 @@ class MujocoDiscEnv(BaseEnv):
     )
 
     def __init__(self, cfg: dict) -> None:
+        super().__init__(cfg)
         self._cfg = cfg
+        # We use env_name to indicate the env_id in LightZero.
+        self._cfg.env_id = self._cfg.env_name
         self._action_clip = cfg.action_clip
         self._delay_reward_step = cfg.delay_reward_step
         self._init_flag = False
@@ -51,7 +46,7 @@ class MujocoDiscEnv(BaseEnv):
     def reset(self) -> np.ndarray:
         if not self._init_flag:
             self._env = self._make_env()
-            self._env.observation_space.dtype = np.float32  # To unify the format of envs in LightZero
+            self._env.observation_space.dtype = np.float32
             self._observation_space = self._env.observation_space
             self._raw_action_space = self._env.action_space
             self._reward_space = gym.spaces.Box(
@@ -89,16 +84,6 @@ class MujocoDiscEnv(BaseEnv):
 
         return obs
 
-    def close(self) -> None:
-        if self._init_flag:
-            self._env.close()
-        self._init_flag = False
-
-    def seed(self, seed: int, dynamic_seed: bool = True) -> None:
-        self._seed = seed
-        self._dynamic_seed = dynamic_seed
-        np.random.seed(self._seed)
-
     def step(self, action: Union[np.ndarray, list]) -> BaseEnvTimestep:
         # disc_to_cont: transform discrete action index to original continuous action
         action = [-1 + 2 / self.n * k for k in self.disc_to_cont[int(action)]]
@@ -129,48 +114,5 @@ class MujocoDiscEnv(BaseEnv):
 
         return BaseEnvTimestep(obs, rew, done, info)
 
-    def _make_env(self):
-        return wrap_mujoco(
-            self._cfg.env_name,
-            norm_obs=self._cfg.get('norm_obs', None),
-            norm_reward=self._cfg.get('norm_reward', None),
-            delay_reward_step=self._delay_reward_step
-        )
-
-    def enable_save_replay(self, replay_path: Optional[str] = None) -> None:
-        if replay_path is None:
-            replay_path = './video'
-        self._replay_path = replay_path
-        self._save_replay = True
-        self._save_replay_count = 0
-
-    def random_action(self) -> np.ndarray:
-        return self.action_space.sample()
-
     def __repr__(self) -> str:
         return "LightZero modified Mujoco Env({}) with manually discretized action space".format(self._cfg.env_name)
-
-    @staticmethod
-    def create_collector_env_cfg(cfg: dict) -> List[dict]:
-        collector_cfg = copy.deepcopy(cfg)
-        collector_env_num = collector_cfg.pop('collector_env_num', 1)
-        return [collector_cfg for _ in range(collector_env_num)]
-
-    @staticmethod
-    def create_evaluator_env_cfg(cfg: dict) -> List[dict]:
-        evaluator_cfg = copy.deepcopy(cfg)
-        evaluator_env_num = evaluator_cfg.pop('evaluator_env_num', 1)
-        evaluator_cfg.norm_reward.use_norm = False
-        return [evaluator_cfg for _ in range(evaluator_env_num)]
-
-    @property
-    def observation_space(self) -> gym.spaces.Space:
-        return self._observation_space
-
-    @property
-    def action_space(self) -> gym.spaces.Space:
-        return self._action_space
-
-    @property
-    def reward_space(self) -> gym.spaces.Space:
-        return self._reward_space

--- a/zoo/mujoco/envs/mujoco_lightzero_env.py
+++ b/zoo/mujoco/envs/mujoco_lightzero_env.py
@@ -1,29 +1,21 @@
-import copy
 import os
-from typing import Union, List, Optional
+from typing import Union
 
 import gym
 import numpy as np
-from ding.envs import BaseEnv, BaseEnvTimestep
+from ding.envs import BaseEnvTimestep
 from ding.envs.common import save_frames_as_gif
 from ding.torch_utils import to_ndarray
 from ding.utils import ENV_REGISTRY
-from dizoo.mujoco.envs.mujoco_wrappers import wrap_mujoco
-from easydict import EasyDict
+from dizoo.mujoco.envs.mujoco_env import MujocoEnv
 
 
 @ENV_REGISTRY.register('mujoco_lightzero')
-class MujocoEnv(BaseEnv):
+class MujocoEnvLZ(MujocoEnv):
     """
     Overview:
         The modified MuJoCo environment with continuous action space for LightZero's algorithms.
     """
-
-    @classmethod
-    def default_config(cls: type) -> EasyDict:
-        cfg = EasyDict(copy.deepcopy(cls.config))
-        cfg.cfg_type = cls.__name__ + 'Dict'
-        return cfg
 
     config = dict(
         stop_value=int(1e6),
@@ -38,7 +30,10 @@ class MujocoEnv(BaseEnv):
     )
 
     def __init__(self, cfg: dict) -> None:
+        super().__init__(cfg)
         self._cfg = cfg
+        # We use env_name to indicate the env_id in LightZero.
+        self._cfg.env_id = self._cfg.env_name
         self._action_clip = cfg.action_clip
         self._delay_reward_step = cfg.delay_reward_step
         self._init_flag = False
@@ -46,24 +41,6 @@ class MujocoEnv(BaseEnv):
         self._replay_path_gif = cfg.replay_path_gif
         self._save_replay_gif = cfg.save_replay_gif
         self._action_bins_per_branch = cfg.action_bins_per_branch
-
-    def map_action(self, action: Union[np.ndarray, list]) -> Union[np.ndarray, list]:
-        """
-        Overview:
-            Map the discretized action index to the action in the original action space.
-        Arguments:
-            - action (:obj:`np.ndarray or list`): The discretized action index. \
-                The value ranges is {0, 1, ..., self._action_bins_per_branch - 1}.
-        Returns:
-            - outputs (:obj:`list`): The action in the original action space. \
-                The value ranges is [-1, 1].
-        Examples:
-            >>> inputs = [2, 0, 4]
-            >>> self._action_bins_per_branch = 5
-            >>> outputs = map_action(inputs)
-            >>> assert isinstance(outputs, list) and outputs == [0.0, -1.0, 1.0]
-        """
-        return [2 * x / (self._action_bins_per_branch - 1) - 1 for x in action]
 
     def reset(self) -> np.ndarray:
         if not self._init_flag:
@@ -76,7 +53,7 @@ class MujocoEnv(BaseEnv):
                     name_prefix='rl-video-{}'.format(id(self))
                 )
 
-            self._env.observation_space.dtype = np.float32  # To unify the format of envs in DI-engine
+            self._env.observation_space.dtype = np.float32
             self._observation_space = self._env.observation_space
             self._action_space = self._env.action_space
             self._reward_space = gym.spaces.Box(
@@ -96,16 +73,6 @@ class MujocoEnv(BaseEnv):
         obs = {'observation': obs, 'action_mask': action_mask, 'to_play': -1}
 
         return obs
-
-    def close(self) -> None:
-        if self._init_flag:
-            self._env.close()
-        self._init_flag = False
-
-    def seed(self, seed: int, dynamic_seed: bool = True) -> None:
-        self._seed = seed
-        self._dynamic_seed = dynamic_seed
-        np.random.seed(self._seed)
 
     def step(self, action: Union[np.ndarray, list]) -> BaseEnvTimestep:
         if self._action_bins_per_branch:
@@ -134,46 +101,6 @@ class MujocoEnv(BaseEnv):
 
         return BaseEnvTimestep(obs, rew, done, info)
 
-    def _make_env(self):
-        return wrap_mujoco(
-            self._cfg.env_name,
-            norm_obs=self._cfg.get('norm_obs', None),
-            norm_reward=self._cfg.get('norm_reward', None),
-            delay_reward_step=self._delay_reward_step
-        )
-
-    def enable_save_replay(self, replay_path: Optional[str] = None) -> None:
-        if replay_path is None:
-            replay_path = './video'
-        self._replay_path = replay_path
-
-    def random_action(self) -> np.ndarray:
-        return self.action_space.sample()
-
     def __repr__(self) -> str:
         return "LightZero Mujoco Env({})".format(self._cfg.env_name)
 
-    @staticmethod
-    def create_collector_env_cfg(cfg: dict) -> List[dict]:
-        collector_cfg = copy.deepcopy(cfg)
-        collector_env_num = collector_cfg.pop('collector_env_num', 1)
-        return [collector_cfg for _ in range(collector_env_num)]
-
-    @staticmethod
-    def create_evaluator_env_cfg(cfg: dict) -> List[dict]:
-        evaluator_cfg = copy.deepcopy(cfg)
-        evaluator_env_num = evaluator_cfg.pop('evaluator_env_num', 1)
-        evaluator_cfg.norm_reward.use_norm = False
-        return [evaluator_cfg for _ in range(evaluator_env_num)]
-
-    @property
-    def observation_space(self) -> gym.spaces.Space:
-        return self._observation_space
-
-    @property
-    def action_space(self) -> gym.spaces.Space:
-        return self._action_space
-
-    @property
-    def reward_space(self) -> gym.spaces.Space:
-        return self._reward_space

--- a/zoo/mujoco/envs/mujoco_lightzero_env.py
+++ b/zoo/mujoco/envs/mujoco_lightzero_env.py
@@ -1,0 +1,179 @@
+import copy
+import os
+from typing import Union, List, Optional
+
+import gym
+import numpy as np
+from ding.envs import BaseEnv, BaseEnvTimestep
+from ding.envs.common import save_frames_as_gif
+from ding.torch_utils import to_ndarray
+from ding.utils import ENV_REGISTRY
+from dizoo.mujoco.envs.mujoco_wrappers import wrap_mujoco
+from easydict import EasyDict
+
+
+@ENV_REGISTRY.register('mujoco_lightzero')
+class MujocoEnv(BaseEnv):
+    """
+    Overview:
+        The modified MuJoCo environment with continuous action space for LightZero's algorithms.
+    """
+
+    @classmethod
+    def default_config(cls: type) -> EasyDict:
+        cfg = EasyDict(copy.deepcopy(cls.config))
+        cfg.cfg_type = cls.__name__ + 'Dict'
+        return cfg
+
+    config = dict(
+        stop_value=int(1e6),
+        action_clip=False,
+        delay_reward_step=0,
+        replay_path=None,
+        save_replay_gif=False,
+        replay_path_gif=None,
+        action_bins_per_branch=None,
+        norm_obs=dict(use_norm=False, ),
+        norm_reward=dict(use_norm=False, ),
+    )
+
+    def __init__(self, cfg: dict) -> None:
+        self._cfg = cfg
+        self._action_clip = cfg.action_clip
+        self._delay_reward_step = cfg.delay_reward_step
+        self._init_flag = False
+        self._replay_path = None
+        self._replay_path_gif = cfg.replay_path_gif
+        self._save_replay_gif = cfg.save_replay_gif
+        self._action_bins_per_branch = cfg.action_bins_per_branch
+
+    def map_action(self, action: Union[np.ndarray, list]) -> Union[np.ndarray, list]:
+        """
+        Overview:
+            Map the discretized action index to the action in the original action space.
+        Arguments:
+            - action (:obj:`np.ndarray or list`): The discretized action index. \
+                The value ranges is {0, 1, ..., self._action_bins_per_branch - 1}.
+        Returns:
+            - outputs (:obj:`list`): The action in the original action space. \
+                The value ranges is [-1, 1].
+        Examples:
+            >>> inputs = [2, 0, 4]
+            >>> self._action_bins_per_branch = 5
+            >>> outputs = map_action(inputs)
+            >>> assert isinstance(outputs, list) and outputs == [0.0, -1.0, 1.0]
+        """
+        return [2 * x / (self._action_bins_per_branch - 1) - 1 for x in action]
+
+    def reset(self) -> np.ndarray:
+        if not self._init_flag:
+            self._env = self._make_env()
+            if self._replay_path is not None:
+                self._env = gym.wrappers.RecordVideo(
+                    self._env,
+                    video_folder=self._replay_path,
+                    episode_trigger=lambda episode_id: True,
+                    name_prefix='rl-video-{}'.format(id(self))
+                )
+
+            self._env.observation_space.dtype = np.float32  # To unify the format of envs in DI-engine
+            self._observation_space = self._env.observation_space
+            self._action_space = self._env.action_space
+            self._reward_space = gym.spaces.Box(
+                low=self._env.reward_range[0], high=self._env.reward_range[1], shape=(1,), dtype=np.float32
+            )
+            self._init_flag = True
+        if hasattr(self, '_seed') and hasattr(self, '_dynamic_seed') and self._dynamic_seed:
+            np_seed = 100 * np.random.randint(1, 1000)
+            self._env.seed(self._seed + np_seed)
+        elif hasattr(self, '_seed'):
+            self._env.seed(self._seed)
+        obs = self._env.reset()
+        obs = to_ndarray(obs).astype('float32')
+        self._eval_episode_return = 0.
+
+        action_mask = None
+        obs = {'observation': obs, 'action_mask': action_mask, 'to_play': -1}
+
+        return obs
+
+    def close(self) -> None:
+        if self._init_flag:
+            self._env.close()
+        self._init_flag = False
+
+    def seed(self, seed: int, dynamic_seed: bool = True) -> None:
+        self._seed = seed
+        self._dynamic_seed = dynamic_seed
+        np.random.seed(self._seed)
+
+    def step(self, action: Union[np.ndarray, list]) -> BaseEnvTimestep:
+        if self._action_bins_per_branch:
+            action = self.map_action(action)
+        action = to_ndarray(action)
+        if self._save_replay_gif:
+            self._frames.append(self._env.render(mode='rgb_array'))
+        if self._action_clip:
+            action = np.clip(action, -1, 1)
+        obs, rew, done, info = self._env.step(action)
+        self._eval_episode_return += rew
+        if done:
+            if self._save_replay_gif:
+                path = os.path.join(
+                    self._replay_path_gif, '{}_episode_{}.gif'.format(self._cfg.env_name, self._save_replay_count)
+                )
+                save_frames_as_gif(self._frames, path)
+                self._save_replay_count += 1
+            info['eval_episode_return'] = self._eval_episode_return
+
+        obs = to_ndarray(obs).astype(np.float32)
+        rew = to_ndarray([rew]).astype(np.float32)
+
+        action_mask = None
+        obs = {'observation': obs, 'action_mask': action_mask, 'to_play': -1}
+
+        return BaseEnvTimestep(obs, rew, done, info)
+
+    def _make_env(self):
+        return wrap_mujoco(
+            self._cfg.env_name,
+            norm_obs=self._cfg.get('norm_obs', None),
+            norm_reward=self._cfg.get('norm_reward', None),
+            delay_reward_step=self._delay_reward_step
+        )
+
+    def enable_save_replay(self, replay_path: Optional[str] = None) -> None:
+        if replay_path is None:
+            replay_path = './video'
+        self._replay_path = replay_path
+
+    def random_action(self) -> np.ndarray:
+        return self.action_space.sample()
+
+    def __repr__(self) -> str:
+        return "LightZero Mujoco Env({})".format(self._cfg.env_name)
+
+    @staticmethod
+    def create_collector_env_cfg(cfg: dict) -> List[dict]:
+        collector_cfg = copy.deepcopy(cfg)
+        collector_env_num = collector_cfg.pop('collector_env_num', 1)
+        return [collector_cfg for _ in range(collector_env_num)]
+
+    @staticmethod
+    def create_evaluator_env_cfg(cfg: dict) -> List[dict]:
+        evaluator_cfg = copy.deepcopy(cfg)
+        evaluator_env_num = evaluator_cfg.pop('evaluator_env_num', 1)
+        evaluator_cfg.norm_reward.use_norm = False
+        return [evaluator_cfg for _ in range(evaluator_env_num)]
+
+    @property
+    def observation_space(self) -> gym.spaces.Space:
+        return self._observation_space
+
+    @property
+    def action_space(self) -> gym.spaces.Space:
+        return self._action_space
+
+    @property
+    def reward_space(self) -> gym.spaces.Space:
+        return self._reward_space


### PR DESCRIPTION
- Add lightzero mujoco env and related sampled efficientzero configs.

- The benchmark results are as follows::
<img width="925" alt="image" src="https://github.com/opendilab/LightZero/assets/48008469/8426c003-befe-4c17-821e-6c2926dcf041">
