### PR TITLE
fix(ekiefl): change `use_act_scale` -> `act_scale`

### DIFF
--- a/zoo/box2d/lunarlander/envs/lunarlander_cont_disc_env.py
+++ b/zoo/box2d/lunarlander/envs/lunarlander_cont_disc_env.py
@@ -71,7 +71,7 @@ class LunarLanderDiscEnv(LunarLanderEnv):
         self._save_replay_gif = cfg.save_replay_gif
         self._save_replay_count = 0
         if 'Continuous' in self._env_name:
-            self._act_scale = cfg.use_act_scale  # act_scale only works in continuous env
+            self._act_scale = cfg.act_scale  # act_scale only works in continuous env
         else:
             self._act_scale = False
 


### PR DESCRIPTION
I believe this was a typo.

I searched the repo for other instances of `use_act_scale` and did not find any.

I'm not sure if the comment is also stale (`# act_scale only works in continuous env`).