### PR TITLE
fix(fir): fix timestep and non-text-based games for muzero

### DIFF
--- a/lzero/policy/stochastic_muzero.py
+++ b/lzero/policy/stochastic_muzero.py
@@ -580,6 +580,7 @@ class StochasticMuZeroPolicy(MuZeroPolicy):
             to_play: List = [-1],
             epsilon: float = 0.25,
             ready_env_id: np.array = None,
+            **kwargs,
     ) -> Dict:
         """
         Overview:
@@ -673,7 +674,7 @@ class StochasticMuZeroPolicy(MuZeroPolicy):
         else:
             self._mcts_eval = MCTSPtree(self._cfg)
 
-    def _forward_eval(self, data: torch.Tensor, action_mask: list, to_play: List = [-1], ready_env_id: np.array = None,) -> Dict:
+    def _forward_eval(self, data: torch.Tensor, action_mask: list, to_play: List = [-1], ready_env_id: np.array = None, **kwargs) -> Dict:
         """
         Overview:
             The forward function for evaluating the current policy in eval mode. Use model to execute MCTS search. \

--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -449,7 +449,7 @@ class MuZeroCollector(ISerialCollector):
                 # print(f'ready_env_id:{ready_env_id}')
                 policy_output = self._policy.forward(stack_obs, action_mask, temperature, to_play, epsilon, ready_env_id=ready_env_id, timestep=timestep)
                 
-                pred_next_text_with_env_id = {k: v['predicted_next_text'] for k, v in policy_output.items()}
+                pred_next_text_with_env_id = {k: v['predicted_next_text'] if 'predicted_next_text' in v else -1 for k, v in policy_output.items()}
                     
                 # Extract relevant policy outputs
                 actions_with_env_id = {k: v['action'] for k, v in policy_output.items()}
@@ -534,8 +534,7 @@ class MuZeroCollector(ISerialCollector):
                     obs, reward, done, info = episode_timestep.obs, episode_timestep.reward, episode_timestep.done, episode_timestep.info
                     
 
-                    
-                    if self.policy_config.model.world_model_cfg.obs_type == 'text':
+                    if "world_model_cfg" in self.policy_config.model and self.policy_config.model.world_model_cfg.obs_type == 'text':
                         obs_input_ids = torch.tensor(obs['observation'], dtype=torch.long)  # shape: [L]
                         obs_attn_mask = torch.tensor(obs['obs_attn_mask'][0], dtype=torch.long)
                         valid_input_ids = obs_input_ids[obs_attn_mask == 1].tolist()
@@ -641,7 +640,7 @@ class MuZeroCollector(ISerialCollector):
                         game_segments[env_id].reset(observation_window_stack[env_id])
 
                     self._env_info[env_id]['step'] += 1
-                    if self.policy_config.model.world_model_cfg.obs_type == 'text':
+                    if "world_model_cfg" in self.policy_config.model and self.policy_config.model.world_model_cfg.obs_type == 'text':
                         self._env_info[env_id]['text_bleu'] += text_bleu
 
                     collected_step += 1
@@ -654,7 +653,7 @@ class MuZeroCollector(ISerialCollector):
                         'time': self._env_info[env_id]['time'],
                         'step': self._env_info[env_id]['step'],
                     }
-                    if self.policy_config.model.world_model_cfg.obs_type == 'text':
+                    if "world_model_cfg" in self.policy_config.model and self.policy_config.model.world_model_cfg.obs_type == 'text':
                         info.update({'text_bleu':self._env_info[env_id]['text_bleu'] / self._env_info[env_id]['step']})
 
                     if not collect_with_pure_policy:
@@ -797,7 +796,7 @@ class MuZeroCollector(ISerialCollector):
             envstep_count = sum([d['step'] for d in self._episode_info])
             duration = sum([d['time'] for d in self._episode_info])
             episode_reward = [d['reward'] for d in self._episode_info]
-            if self.policy_config.model.world_model_cfg.obs_type == 'text':
+            if "world_model_cfg" in self.policy_config.model and self.policy_config.model.world_model_cfg.obs_type == 'text':
                 episode_bleu = [d['text_bleu'] for d in self._episode_info]
 
             if not self.collect_with_pure_policy:
@@ -823,7 +822,7 @@ class MuZeroCollector(ISerialCollector):
                 'total_duration': self._total_duration,
                 'visit_entropy': np.mean(visit_entropy),
             }
-            if self.policy_config.model.world_model_cfg.obs_type == 'text':
+            if "world_model_cfg" in self.policy_config.model and self.policy_config.model.world_model_cfg.obs_type == 'text':
                 info.update({'text_avg_bleu':np.mean(episode_bleu)})
             if self.policy_config.gumbel_algo:
                 info['completed_value'] = np.mean(completed_value)


### PR DESCRIPTION
- Last update "enhance text based game" broke the usage of muzero since the management of text based game has been added, but the default behaviour for non-text based game hasn't been defied, therefore raising a _self.policy_config.model has no "world_model_cfg" attribute_ error. My fix make so that if the config miss the text-related argument that is checked in the muzero_collector, the muzero_collector it ignores the text-related beaviour

- Added a fallback case if the policy output has no 'predicted_next_state' attribute, for all the non-text-based environments

- Added kwargs to stochastic muzero policy forward functions, following the examples of the others policies. Otherwise, a call to stochastic muzero was raising an error of _TypeError: StochasticMuZeroPolicy._forward_eval() got an unexpected keyword argument 'timestep'_