### PR TITLE
(fir):fix (stochastic) muzero collector/evaluator

### DIFF
--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -565,7 +565,7 @@ class MuZeroCollector(ISerialCollector):
                     if self.policy_config.use_ture_chance_label_in_chance_encoder:
                         game_segments[env_id].append(
                             actions[env_id], to_ndarray(obs['observation']), reward, action_mask_dict[env_id],
-                            to_play_dict[env_id], chance_dict[env_id], timestep_dict[env_id]
+                            to_play_dict[env_id], timestep_dict[env_id], chance_dict[env_id]
                         )
                     else:
                         game_segments[env_id].append(


### PR DESCRIPTION
Fix _muzero_collector/evaluator_ interaction with _game_segment_ in the scope of Stochastic MuZero with chance nodes

Stochastic MuZero isn't working in current implementation. My analysis is that the method _GameSegment.append_ changed after Stochastic MuZero's tests two years ago. I spotted the bug by running unmodified _zoo/game_2048/config/stochastic_muzero_2048_config.py_

- _muzero_collector_ had a mixup between timestep arg and chance arg. Therefore, timesteps were wrongfully taken as chance, and raise afterwards errors later in the pipeline, in the one hot encoding (sometimes timestep < 0 or timestep > chance_space_size, thus creating chaos)
- _muzero_evaluator_ was not at all feeding chance-related content to GameSegment

**The fix for _muzero_collector_ is obvious.
I fixed _muzero_evaluator_ since I understood that it should also use the chance encoding, but I am only 99% sure about it. (perhaps the evaluator is used for validation and shouldn't have access to ground-truth for chance ?)**

With these modifications running unmodified _zoo/game_2048/config/stochastic_muzero_2048_config.py_ now works.

I'd need @puyuan1996 validation about _muzero_evaluator_, to confirm that it indeed should handle chance nodes just as _muzero_collector_ does.