### PR TITLE
Use ENV_REGISTRY for loading AlphaZero simulation environments

### DIFF
--- a/lzero/entry/train_alphazero.py
+++ b/lzero/entry/train_alphazero.py
@@ -58,6 +58,11 @@ def train_alphazero(
     collector_env.seed(cfg.seed)
     evaluator_env.seed(cfg.seed, dynamic_seed=False)
     set_pkg_seed(cfg.seed, use_cuda=cfg.policy.cuda)
+
+    # Pass full config to policy so it can access cfg.env and create_cfg for simulation env
+    cfg.policy.full_cfg = cfg
+    cfg.policy.create_cfg = create_cfg
+
     policy = create_policy(cfg.policy, model=model, enable_field=['learn', 'collect', 'eval'])
 
     # load pretrained model

--- a/lzero/policy/alphazero.py
+++ b/lzero/policy/alphazero.py
@@ -337,58 +337,22 @@ class AlphaZeroPolicy(Policy):
         return output
 
     def _get_simulation_env(self):
-        if self._cfg.simulation_env_id == 'tictactoe':
-            from zoo.board_games.tictactoe.envs.tictactoe_env import TicTacToeEnv
-            if self._cfg.simulation_env_config_type == 'play_with_bot':
-                from zoo.board_games.tictactoe.config.tictactoe_alphazero_bot_mode_config import \
-                    tictactoe_alphazero_config
-            elif self._cfg.simulation_env_config_type == 'self_play':
-                from zoo.board_games.tictactoe.config.tictactoe_alphazero_sp_mode_config import \
-                    tictactoe_alphazero_config
-            else:
-                raise NotImplementedError
-            self.simulate_env = TicTacToeEnv(tictactoe_alphazero_config.env)
+        """
+        Overview:
+            Create simulation environment for MCTS using registry-based approach.
+            Uses ENV_REGISTRY to instantiate environment based on simulation_env_id.
+        """
+        from ding.utils import import_module, ENV_REGISTRY
 
-        elif self._cfg.simulation_env_id == 'gomoku':
-            from zoo.board_games.gomoku.envs.gomoku_env import GomokuEnv
-            if self._cfg.simulation_env_config_type == 'play_with_bot':
-                from zoo.board_games.gomoku.config.gomoku_alphazero_bot_mode_config import gomoku_alphazero_config
-            elif self._cfg.simulation_env_config_type == 'self_play':
-                from zoo.board_games.gomoku.config.gomoku_alphazero_sp_mode_config import gomoku_alphazero_config
-            else:
-                raise NotImplementedError
-            self.simulate_env = GomokuEnv(gomoku_alphazero_config.env)
-        elif self._cfg.simulation_env_id == 'connect4':
-            from zoo.board_games.connect4.envs.connect4_env import Connect4Env
-            if self._cfg.simulation_env_config_type == 'play_with_bot':
-                from zoo.board_games.connect4.config.connect4_alphazero_bot_mode_config import connect4_alphazero_config
-            elif self._cfg.simulation_env_config_type == 'self_play':
-                from zoo.board_games.connect4.config.connect4_alphazero_sp_mode_config import connect4_alphazero_config
-            else:
-                raise NotImplementedError
-            self.simulate_env = Connect4Env(connect4_alphazero_config.env)
-        elif self._cfg.simulation_env_id == 'chess':
-            from zoo.board_games.chess.envs.chess_lightzero_env import ChessLightZeroEnv
-            if self._cfg.simulation_env_config_type == 'play_with_bot':
-                from zoo.board_games.chess.config.chess_alphazero_bot_mode_config import chess_alphazero_config
-            elif self._cfg.simulation_env_config_type == 'self_play':
-                from zoo.board_games.chess.config.chess_alphazero_sp_mode_config import chess_alphazero_config
-            else:
-                raise NotImplementedError
-            self.simulate_env = ChessLightZeroEnv(chess_alphazero_config.env)
-        elif self._cfg.simulation_env_id == 'dummy_any_game':
-            from zoo.board_games.tictactoe.envs.dummy_any_game_env import AnyGameEnv
-            if self._cfg.simulation_env_config_type == 'single_player_mode':
-                from zoo.board_games.tictactoe.config.dummy_any_game_alphazero_single_player_mode_config import \
-                    dummy_any_game_alphazero_config
-            elif self._cfg.simulation_env_config_type == 'self_play':
-                from zoo.board_games.tictactoe.config.dummy_any_game_alphazero_self_play_mode_config import \
-                    dummy_any_game_alphazero_config
-            else:
-                raise NotImplementedError
-            self.simulate_env = AnyGameEnv(dummy_any_game_alphazero_config.env)
-        else:
-            raise NotImplementedError
+        # Import env modules to trigger registration
+        import_names = self._cfg.create_cfg.env.get('import_names', [])
+        import_module(import_names)
+
+        # Get env class from registry
+        env_cls = ENV_REGISTRY.get(self._cfg.simulation_env_id)
+
+        # Create simulation env with config from main config
+        self.simulate_env = env_cls(self._cfg.full_cfg.env)
 
     @torch.no_grad()
     def _policy_value_fn(self, env: 'Env') -> Tuple[Dict[int, np.ndarray], float]:  # noqa


### PR DESCRIPTION
  ## Background (DI-engine pattern)

  DI-engine already loads classes for collector and evaluator environments via `ENV_REGISTRY` (using `get_vec_env_setting()` in
  DI-engine's `base_env.py`). However, the simulation environment class used by MCTS in AlphaZero policies was still loaded through
  hardcoded imports.

  ## Changes

  This PR completes the registry-based approach by refactoring simulation environment class loading to use `ENV_REGISTRY`, matching the
  pattern used by DI-engine for collector/evaluator environments.

  - Modified `train_alphazero.py` to pass `full_cfg` and `create_cfg` to policy config
  - Replaced hardcoded `_get_simulation_env()` in all 3 AlphaZero policies:
    - `lzero/policy/alphazero.py`
    - `lzero/policy/gumbel_alphazero.py`
    - `lzero/policy/sampled_alphazero.py`

  ## Benefits

  - **Consistency**: All environment types (collector, evaluator, simulation) now load their classes via the same registry
  - **Extensibility**: New environments can be added without modifying core LightZero code
  - **Reduces code duplication**: ~130 lines of hardcoded imports removed

  ## Testing

  Tested and verified with:
  - ✓ Gomoku Gumbel AlphaZero
  - ✓ TicTacToe AlphaZero
  - ✓ TicTacToe Sampled AlphaZero

  All tests passed successfully.