### PR TITLE
fix(SteamMachinist): fix inconsistent parameter name in MuZeroCollector and MuZeroPolicy

### DIFF
--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -340,6 +340,7 @@ class MuZeroCollector(ISerialCollector):
 
         # --- Initializations ---
         collected_episode = 0
+        collected_step = 0
         env_nums = self._env_num
         retry_waiting_time = 0.05
 

--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -411,7 +411,7 @@ class MuZeroCollector(ISerialCollector):
                 # Policy Forward Pass
                 # ==============================================================
                 policy_input = {
-                    'x': stack_obs_tensor,
+                    'data': stack_obs_tensor,
                     'action_mask': action_mask,
                     'temperature': temperature,
                     'to_play': to_play,


### PR DESCRIPTION
rename param x->data in policy forward call