### PR TITLE
fix(RubenRamdewor): reset parent_q per batch element in batch_traverse

### DIFF
--- a/lzero/mcts/ctree/ctree_efficientzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_efficientzero/lib/cnode.cpp
@@ -901,7 +901,6 @@ namespace tree
         get_time_and_set_rand_seed();
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -917,6 +916,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;
@@ -982,7 +982,6 @@ namespace tree
         get_time_and_set_rand_seed();
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -998,6 +997,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;

--- a/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp
@@ -850,7 +850,6 @@ namespace tree{
         srand(t1.tv_usec);
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;

--- a/lzero/mcts/ctree/ctree_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_muzero/lib/cnode.cpp
@@ -770,7 +770,6 @@ namespace tree
         get_time_and_set_rand_seed();
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -782,6 +781,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;
@@ -845,7 +845,6 @@ namespace tree
         get_time_and_set_rand_seed();
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -857,6 +856,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;

--- a/lzero/mcts/ctree/ctree_sampled_efficientzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_sampled_efficientzero/lib/cnode.cpp
@@ -1132,7 +1132,6 @@ namespace tree
         }
         // CAction last_action = CAction(null_value, 1);
         std::vector<float> last_action;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -1144,6 +1143,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;

--- a/lzero/mcts/ctree/ctree_sampled_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_sampled_muzero/lib/cnode.cpp
@@ -1123,7 +1123,6 @@ namespace tree
             null_value.push_back(i + 0.1);
         }
         std::vector<float> last_action;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -1135,6 +1134,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;

--- a/lzero/mcts/ptree/ptree_ez.py
+++ b/lzero/mcts/ptree/ptree_ez.py
@@ -474,7 +474,6 @@ def batch_traverse(
         - virtual_to_play (:obj:`Union[list, int]`): The to_play list used in self_play collecting and trainin gin board games,
             `virtual` is to emphasize that actions are performed on an imaginary hidden state.
     """
-    parent_q = 0.0
     results.search_lens = [None for _ in range(results.num)]
     results.last_actions = [None for _ in range(results.num)]
     results.nodes = [None for _ in range(results.num)]
@@ -494,6 +493,7 @@ def batch_traverse(
             players = 1
 
     for i in range(results.num):
+        parent_q = 0.0
         node = roots.roots[i]
         is_root = 1
         search_len = 0

--- a/lzero/mcts/ptree/ptree_mz.py
+++ b/lzero/mcts/ptree/ptree_mz.py
@@ -446,7 +446,6 @@ def batch_traverse(
         - virtual_to_play (:obj:`list`): The to_play list used in self_play collecting and trainin gin board games,
             `virtual` is to emphasize that actions are performed on an imaginary hidden state.
     """
-    parent_q = 0.0
     results.search_lens = [None for _ in range(results.num)]
     results.last_actions = [None for _ in range(results.num)]
 
@@ -460,6 +459,7 @@ def batch_traverse(
 
     results.search_paths = {i: [] for i in range(results.num)}
     for i in range(results.num):
+        parent_q = 0.0
         node = roots.roots[i]
         is_root = 1
         search_len = 0

--- a/lzero/mcts/ptree/ptree_sez.py
+++ b/lzero/mcts/ptree/ptree_sez.py
@@ -666,7 +666,6 @@ def batch_traverse(
         - virtual_to_play (:obj:`list`): The to_play list used in self_play collecting and trainin gin board games,
             `virtual` is to emphasize that actions are performed on an imaginary hidden state.
     """
-    parent_q = 0.0
     results.search_lens = [None for _ in range(results.num)]
     results.last_actions = [None for _ in range(results.num)]
 
@@ -680,6 +679,7 @@ def batch_traverse(
 
     results.search_paths = {i: [] for i in range(results.num)}
     for i in range(results.num):
+        parent_q = 0.0
         node = roots.roots[i]
         is_root = 1
         search_len = 0

--- a/lzero/mcts/ptree/ptree_stochastic_mz.py
+++ b/lzero/mcts/ptree/ptree_stochastic_mz.py
@@ -486,7 +486,6 @@ def batch_traverse(
         - virtual_to_play (:obj:`list`): The to_play list used in self_play collecting and trainin gin board games,
             `virtual` is to emphasize that actions are performed on an imaginary hidden state.
     """
-    parent_q = 0.0
     results.search_lens = [None for i in range(results.num)]
     results.last_actions = [None for i in range(results.num)]
 
@@ -500,6 +499,7 @@ def batch_traverse(
 
     results.search_paths = {i: [] for i in range(results.num)}
     for i in range(results.num):
+        parent_q = 0.0
         node = roots.roots[i]
         is_root = 1
         search_len = 0


### PR DESCRIPTION
## Bug Fix: Reset `parent_q` per batch element in `batch_traverse`

### Bug Description

A subtle but impactful bug was present in the `batch_traverse` function across all tree implementations (both Python `ptree` and C++ `ctree` variants).

`parent_q` — the Q-value of the parent node passed down during tree traversal — was initialized **once before the batch loop**, causing its value to **leak from one environment to the next** within the same batch:

```python
# BEFORE (buggy)
parent_q = 0.0          # initialized once for the whole batch
for i in range(results.num):
    node = roots.roots[i]
    while node.expanded:
        mean_q = node.compute_mean_q(is_root, parent_q, ...)  # wrong for i > 0
        parent_q = mean_q
```

```python
# AFTER (fixed)
for i in range(results.num):
    parent_q = 0.0      # correctly reset for each independent environment
    node = roots.roots[i]
    while node.expanded:
        mean_q = node.compute_mean_q(is_root, parent_q, ...)
        parent_q = mean_q
```

For `i=0` the behaviour was correct. For every subsequent environment `i > 0`, the first call to `compute_mean_q` at the root received a stale `parent_q` inherited from the final traversal step of the previous environment instead of `0.0`.

> **Note:** `ctree_stochastic_muzero` already had this fix with an explicit comment: `// Phase 3c fix: parent_q must be reset for each batch element independently`. This PR propagates the same correction to all remaining implementations.

---

### Files Modified

| File                                                           | Type                                          |
| -------------------------------------------------------------- | --------------------------------------------- |
| `lzero/mcts/ptree/ptree_mz.py`                               | Python tree (MuZero)                          |
| `lzero/mcts/ptree/ptree_stochastic_mz.py`                    | Python tree (Stochastic MuZero)               |
| `lzero/mcts/ptree/ptree_sez.py`                              | Python tree (Sampled EfficientZero)           |
| `lzero/mcts/ptree/ptree_ez.py`                               | Python tree (EfficientZero)                   |
| `lzero/mcts/ctree/ctree_muzero/lib/cnode.cpp`                | C++ tree (MuZero) — 2 functions              |
| `lzero/mcts/ctree/ctree_sampled_muzero/lib/cnode.cpp`        | C++ tree (Sampled MuZero)                     |
| `lzero/mcts/ctree/ctree_efficientzero/lib/cnode.cpp`         | C++ tree (EfficientZero) — 2 functions       |
| `lzero/mcts/ctree/ctree_sampled_efficientzero/lib/cnode.cpp` | C++ tree (Sampled EfficientZero)              |
| `lzero/mcts/ctree/ctree_gumbel_muzero/lib/cnode.cpp`         | C++ tree (Gumbel MuZero) — dead code removed |

---

### Impact on Training Quality

#### 1. Correctness of `compute_mean_q` at the root

`parent_q` is used by `compute_mean_q` to compute the mean Q-value at a node, which is then passed to `select_child` as the reference Q-value for the pUCT formula. At the root, the contract is that `parent_q = 0.0` (no parent above the root). When `parent_q` was non-zero due to the bug, the mean Q estimate at the root was biased by the traversal history of a completely different, independent environment.

#### 2. Bias in action selection (pUCT)

The pUCT score used in `select_child` depends on `mean_q` to normalize Q-values. A wrong `parent_q` at the root shifts the exploration/exploitation balance:

- If the leaked `parent_q` is **higher** than expected → the algorithm **underestimates** child quality → **over-exploration**
- If it is **lower** → the algorithm **overestimates** child quality → **over-exploitation**

This asymmetry is non-deterministic and varies with batch order, making it especially hard to debug.

#### 3. Effect on convergence

In a batch of `N` environments, `N-1` out of `N` root selections were potentially corrupted at every simulation step. Since MCTS quality directly determines the quality of the policy targets used for training (via visit count distributions), corrupted selections propagate into the training data:

- The policy network learns from slightly wrong action distributions
- The value network receives slightly wrong bootstrapped targets
- Over thousands of training steps, this slows convergence and increases variance in the learning signal

The larger the batch size, the larger the proportion of affected environments per step, and the more pronounced the effect.

#### 4. Reproducibility

Because the leaked `parent_q` depends on the traversal depth and Q-values of the previous environment (which vary during training), the corruption is **non-stationary and non-deterministic**. This makes experiments harder to reproduce and results harder to interpret.

---

### Expected Improvements After Fix

- More consistent and theoretically correct MCTS simulations across all environments in a batch
- Reduced variance in policy and value targets → **smoother and faster convergence**
- More reliable action selection at the root, particularly in early training when Q-value estimates are noisy
- Results become more **reproducible** across runs and batch sizes
- All tree variants are now aligned with `ctree_stochastic_muzero`, which was the only implementation already handling this correctly