### PR TITLE
fix(RubenRamdewor): reset parent_q per batch element in ctree_stochastic_muzero (#474 follow-up)

### DIFF
--- a/lzero/mcts/ctree/ctree_stochastic_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_stochastic_muzero/lib/cnode.cpp
@@ -726,7 +726,6 @@ namespace tree
         get_time_and_set_rand_seed();
 
         int last_action = -1;
-        float parent_q = 0.0;
         results.search_lens = std::vector<int>();
 
         int players = 0;
@@ -738,6 +737,7 @@ namespace tree
 
         for (int i = 0; i < results.num; ++i)
         {
+            float parent_q = 0.0;
             CNode *node = &(roots->roots[i]);
             int is_root = 1;
             int search_len = 0;


### PR DESCRIPTION


PR #474 fixed the parent_q bleeding bug in batch_traverse across all ptree and ctree variants, but ctree_stochastic_muzero/lib/cnode.cpp was accidentally omitted from the patch.

parent_q was initialized once before the batch loop, causing its value to carry over from element i-1 into element i's traversal. Each traversal must start with parent_q=0.0 at the root so that compute_mean_q is not biased by a previous batch element's final Q value.

This commit applies the identical one-line fix: move `float parent_q = 0.0;` from outside the for-loop to inside it.
