### PR TITLE
fix(pu): index sampled target policies by slot

### DIFF
--- a/lzero/mcts/buffer/game_buffer_muzero.py
+++ b/lzero/mcts/buffer/game_buffer_muzero.py
@@ -75,6 +75,18 @@ class MuZeroGameBuffer(GameBuffer):
         self.value_support = DiscreteSupport(*self._cfg.model.value_support_range)
         self.reward_support = DiscreteSupport(*self._cfg.model.reward_support_range)
 
+    def _assign_target_policy_for_legal_actions(
+            self, policy_tmp: List[float], policy: List[float], legal_actions: List[int]
+    ) -> None:
+        """
+        Assign visit-count policy values into the target policy vector.
+
+        Non-sampled algorithms use a full action-space policy vector, so each legal action is the destination index.
+        Sampled algorithms override this method because their target policy vector is indexed by sampled-action slot.
+        """
+        for index, legal_action in enumerate(legal_actions):
+            policy_tmp[legal_action] = policy[index]
+
     def reset_runtime_metrics(self):
         """
         Overview:
@@ -704,8 +716,9 @@ class MuZeroGameBuffer(GameBuffer):
                                 # to make sure target_policies have the same dimension
                                 sum_visits = sum(distributions)
                                 policy = [visit_count / sum_visits for visit_count in distributions]
-                                for index, legal_action in enumerate(roots_legal_actions_list[policy_index]):
-                                    policy_tmp[legal_action] = policy[index]
+                                self._assign_target_policy_for_legal_actions(
+                                    policy_tmp, policy, roots_legal_actions_list[policy_index]
+                                )
                                 target_policies.append(policy_tmp)
 
                     policy_index += 1
@@ -777,9 +790,10 @@ class MuZeroGameBuffer(GameBuffer):
                         else:
                             # for board games that have two players or envs that have varied action space.
                             policy_tmp = [0 for _ in range(policy_shape)]
-                            for index, legal_action in enumerate(legal_actions[policy_index]):
-                                # only the action in ``legal_action`` the policy logits is nonzero
-                                policy_tmp[legal_action] = distributions[index]
+                            # only the action in ``legal_action`` the policy logits is nonzero
+                            self._assign_target_policy_for_legal_actions(
+                                policy_tmp, distributions, legal_actions[policy_index]
+                            )
                             target_policies.append(policy_tmp)
                     else:
                         # NOTE: the invalid padding target policy, O is to make sure the corresponding cross_entropy_loss=0

--- a/lzero/mcts/buffer/game_buffer_sampled_efficientzero.py
+++ b/lzero/mcts/buffer/game_buffer_sampled_efficientzero.py
@@ -48,6 +48,15 @@ class SampledEfficientZeroGameBuffer(EfficientZeroGameBuffer):
         self.value_support = DiscreteSupport(*self._cfg.model.value_support_range)
         self.reward_support = DiscreteSupport(*self._cfg.model.reward_support_range)
 
+    def _assign_target_policy_for_legal_actions(
+            self, policy_tmp: List[float], policy: List[float], legal_actions: List[int]
+    ) -> None:
+        """
+        Sampled policies are stored in sampled-action order, not in the full environment action-space index.
+        """
+        for index, policy_value in enumerate(policy):
+            policy_tmp[index] = policy_value
+
     def sample(self, batch_size: int, policy: Any) -> List[Any]:
         """
         Overview:
@@ -574,8 +583,9 @@ class SampledEfficientZeroGameBuffer(EfficientZeroGameBuffer):
                                 # to make sure target_policies have the same dimension
                                 sum_visits = sum(distributions)
                                 policy = [visit_count / sum_visits for visit_count in distributions]
-                                for index, legal_action in enumerate(roots_legal_actions_list[policy_index]):
-                                    policy_tmp[legal_action] = policy[index]
+                                self._assign_target_policy_for_legal_actions(
+                                    policy_tmp, policy, roots_legal_actions_list[policy_index]
+                                )
                                 target_policies.append(policy_tmp)
 
                     policy_index += 1

--- a/lzero/mcts/buffer/game_buffer_sampled_muzero.py
+++ b/lzero/mcts/buffer/game_buffer_sampled_muzero.py
@@ -48,6 +48,15 @@ class SampledMuZeroGameBuffer(MuZeroGameBuffer):
         self.value_support = DiscreteSupport(*self._cfg.model.value_support_range)
         self.reward_support = DiscreteSupport(*self._cfg.model.reward_support_range)
 
+    def _assign_target_policy_for_legal_actions(
+            self, policy_tmp: List[float], policy: List[float], legal_actions: List[int]
+    ) -> None:
+        """
+        Sampled policies are stored in sampled-action order, not in the full environment action-space index.
+        """
+        for index, policy_value in enumerate(policy):
+            policy_tmp[index] = policy_value
+
     def sample(self, batch_size: int, policy: Any) -> List[Any]:
         """
         Overview:
@@ -555,8 +564,9 @@ class SampledMuZeroGameBuffer(MuZeroGameBuffer):
                                 # to make sure target_policies have the same dimension
                                 sum_visits = sum(distributions)
                                 policy = [visit_count / sum_visits for visit_count in distributions]
-                                for index, legal_action in enumerate(roots_legal_actions_list[policy_index]):
-                                    policy_tmp[legal_action] = policy[index]
+                                self._assign_target_policy_for_legal_actions(
+                                    policy_tmp, policy, roots_legal_actions_list[policy_index]
+                                )
                                 target_policies.append(policy_tmp)
 
                     policy_index += 1

--- a/lzero/mcts/tests/test_game_buffer.py
+++ b/lzero/mcts/tests/test_game_buffer.py
@@ -4,6 +4,9 @@ from easydict import EasyDict
 
 from ding.torch_utils import to_list
 from lzero.mcts.buffer.game_buffer_efficientzero import EfficientZeroGameBuffer
+from lzero.mcts.buffer.game_buffer_muzero import MuZeroGameBuffer
+from lzero.mcts.buffer.game_buffer_sampled_efficientzero import SampledEfficientZeroGameBuffer
+from lzero.mcts.buffer.game_buffer_sampled_muzero import SampledMuZeroGameBuffer
 
 config = EasyDict(
     dict(
@@ -23,6 +26,41 @@ config = EasyDict(
         ),
     )
 )
+
+
+def _make_varied_action_config(action_space_size=100, num_of_sampled_actions=3):
+    return EasyDict(
+        dict(
+            batch_size=2,
+            priority_prob_alpha=0.6,
+            priority_prob_beta=0.4,
+            replay_buffer_size=100,
+            env_type='board_games',
+            use_priority=False,
+            action_type='varied_action_space',
+            game_segment_length=10,
+            num_unroll_steps=0,
+            model=dict(
+                action_space_size=action_space_size,
+                continuous_action_space=False,
+                num_of_sampled_actions=num_of_sampled_actions,
+                value_support_range=(-10, 10, 1),
+                reward_support_range=(-10, 10, 1),
+            ),
+        )
+    )
+
+
+def _make_sparse_policy_context(action_space_size=100):
+    action_mask = np.zeros(action_space_size, dtype=np.int8)
+    action_mask[[7, 42, 99]] = 1
+    return [
+        [0],
+        [[[0.2, 0.3, 0.5]]],
+        [1],
+        [[action_mask]],
+        [[-1]],
+    ]
 
 
 @pytest.mark.unittest
@@ -93,3 +131,29 @@ def test_sample_orig_data():
     context = buffer._sample_orig_data(batch_size=2)
     # context = (game_lst, game_pos_lst, indices_lst, weights, make_time)
     print(context)
+
+
+@pytest.mark.unittest
+def test_non_sampled_varied_action_policy_maps_to_action_ids():
+    buffer = MuZeroGameBuffer(_make_varied_action_config())
+
+    target_policies = buffer._compute_target_policy_non_reanalyzed(
+        _make_sparse_policy_context(), policy_shape=100
+    )
+
+    assert target_policies.shape == (1, 1, 100)
+    np.testing.assert_allclose(target_policies[0, 0, [7, 42, 99]], [0.2, 0.3, 0.5])
+    assert target_policies[0, 0].sum() == pytest.approx(1.0)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize('buffer_cls', [SampledMuZeroGameBuffer, SampledEfficientZeroGameBuffer])
+def test_sampled_varied_action_policy_uses_sampled_action_indices(buffer_cls):
+    buffer = buffer_cls(_make_varied_action_config())
+
+    target_policies = buffer._compute_target_policy_non_reanalyzed(
+        _make_sparse_policy_context(), policy_shape=3
+    )
+
+    assert target_policies.shape == (1, 1, 3)
+    np.testing.assert_allclose(target_policies[0, 0], [0.2, 0.3, 0.5])


### PR DESCRIPTION
Closes #486

## Summary
- Keep base MuZero target policy assignment indexed by real legal action ids.
- Override sampled MuZero/EfficientZero target policy assignment to use sampled-action slots instead of sparse environment action ids.
- Route both non-reanalyzed and sampled reanalyzed target policy construction through the same assignment helper.
- Add a regression test for sparse legal action ids with SampledMuZeroGameBuffer and SampledEfficientZeroGameBuffer.

## Tests
- /mnt/shared-storage-user/puyuan/lz/bin/python -m pytest lzero/mcts/tests/test_game_buffer.py -q
- /mnt/shared-storage-user/puyuan/lz/bin/python -m py_compile lzero/mcts/buffer/game_buffer_muzero.py lzero/mcts/buffer/game_buffer_sampled_muzero.py lzero/mcts/buffer/game_buffer_sampled_efficientzero.py lzero/mcts/tests/test_game_buffer.py
- /mnt/shared-storage-user/puyuan/lz/bin/python -m pytest lzero/model/tests/test_sampled_efficientzero_model.py -q