### PR TITLE
fix(mc): fix search tree memory leaks in AlphaZero ctree variants

### DIFF
--- a/lzero/mcts/ctree/ctree_alphazero/node_alphazero.cpp
+++ b/lzero/mcts/ctree/ctree_alphazero/node_alphazero.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(node_alphazero, m) {
         .def("is_leaf", &Node::is_leaf)
         .def("is_root", &Node::is_root)
         .def("parent", [](const Node& self) -> std::shared_ptr<Node> {
-            return self.parent;
+            return self.parent.lock();
         })
         .def("children", [](const Node& self) -> std::map<int, std::shared_ptr<Node>> {
             return self.children;

--- a/lzero/mcts/ctree/ctree_alphazero/node_alphazero.h
+++ b/lzero/mcts/ctree/ctree_alphazero/node_alphazero.h
@@ -9,8 +9,10 @@
 
 class Node : public std::enable_shared_from_this<Node> {
 public:
-    // Parent and child nodes are managed using shared_ptr
-    std::shared_ptr<Node> parent;
+    // The parent is held as a weak_ptr: children own nothing about their parent, so the
+    // parent<->child shared_ptr cycle is broken and trees are actually freed once the
+    // last external reference to the root is dropped.
+    std::weak_ptr<Node> parent;
     std::map<int, std::shared_ptr<Node>> children;
 
     // Constructor
@@ -39,16 +41,16 @@ public:
             // Self-play mode: update the current node and recursively update the parent node
             // (pass the negative leaf_value).
             update(leaf_value);
-            if (!is_root()) {
-                parent->update_recursive(-leaf_value, battle_mode_in_simulation_env);
+            if (auto p = parent.lock()) {
+                p->update_recursive(-leaf_value, battle_mode_in_simulation_env);
             }
         }
         else if (battle_mode_in_simulation_env == "play_with_bot_mode") {
             // Play-with-bot mode: update the current node and recursively update the parent node
             // (pass the same leaf_value).
             update(leaf_value);
-            if (!is_root()) {
-                parent->update_recursive(leaf_value, battle_mode_in_simulation_env);
+            if (auto p = parent.lock()) {
+                p->update_recursive(leaf_value, battle_mode_in_simulation_env);
             }
         }
         else {
@@ -66,7 +68,7 @@ public:
 
     // Check if the node is the root node
     bool is_root() const {
-        return parent == nullptr;
+        return parent.expired();
     }
 
     // Add a child node
@@ -79,7 +81,7 @@ public:
 
     // Get the parent node
     std::shared_ptr<Node> get_parent() const {
-        return parent;
+        return parent.lock();
     }
 
     // Get the child nodes

--- a/lzero/mcts/ctree/ctree_gumbel_alphazero/mcts_gumbel_alphazero.cpp
+++ b/lzero/mcts/ctree/ctree_gumbel_alphazero/mcts_gumbel_alphazero.cpp
@@ -476,7 +476,10 @@ public:
     
     // This function returns the next action to take and the probabilities of each action based on the current state and the policy-value function.
     std::tuple<int, std::vector<double>, std::vector<double>> get_next_action(py::object state_config_for_env_reset, py::object policy_forward_fn, double temperature, bool sample) {
-        Node* root = new Node();
+        // Own the root so the whole search tree is freed when this call returns
+        // (~Node recursively deletes children); previously the tree leaked every move.
+        std::unique_ptr<Node> root_owner(new Node());
+        Node* root = root_owner.get();
         py::object init_state = state_config_for_env_reset["init_state"];
         if (!init_state.is_none()) {
             init_state = py::bytes(init_state.attr("tobytes")());

--- a/zoo/board_games/gomoku/config/gomoku_alphazero_bot_mode_config.py
+++ b/zoo/board_games/gomoku/config/gomoku_alphazero_bot_mode_config.py
@@ -12,7 +12,7 @@ update_per_collect = 50
 batch_size = 256
 max_env_step = int(5e5)
 prob_random_action_in_bot = 0.5
-mcts_ctree = False
+mcts_ctree = True
 # ==============================================================
 # end of the most frequently changed config specified by the user
 # ==============================================================


### PR DESCRIPTION
Hi, there is a memory leak issue with the AlphaZero implementation.

Both C++ AlphaZero trees never free their search trees. In `ctree_alphazero`, parent and child nodes hold `shared_ptr`s to each other, and in `ctree_gumbel_alphazero` the root is made using `new` and never deleted.

This fix uses a `weak_ptr` parent and owns the gumbel root with a `unique_ptr`.

The second commit also flips `mcts_ctree=True` in the gomoku AlphaZero config, since the C++ tree no longer leaks. If the `False` default was intentional, please feel free to drop that commit.

Memory use in the same training setup, before and after the fix:
<img width="1575" height="780" alt="memory_graph" src="https://github.com/user-attachments/assets/39007540-5884-4ad9-a095-9de557b7364a" />

