### PR TITLE
fix(pu): restore UniZero training semantics, especially fix double frame skipping bug

### DIFF
--- a/lzero/entry/tests/test_train_unizero_segment_resume.py
+++ b/lzero/entry/tests/test_train_unizero_segment_resume.py
@@ -1,0 +1,58 @@
+import pytest
+
+from lzero.entry.train_unizero_segment import _required_replay_transitions, _restore_resume_counters
+
+
+class _CountVar:
+
+    def __init__(self):
+        self.value = 0
+
+    def update(self, value):
+        self.value = value
+
+
+class _Learner:
+
+    def __init__(self):
+        self._last_iter = _CountVar()
+        self.collector_envstep = 0
+
+
+class _Collector:
+
+    def __init__(self):
+        self._total_envstep_count = 0
+
+
+def test_restore_resume_counters_updates_collector_and_checkpoint_owner():
+    learner = _Learner()
+    collector = _Collector()
+
+    _restore_resume_counters(learner, collector, train_iter=10023, envstep=101278)
+
+    assert learner._last_iter.value == 10023
+    assert collector._total_envstep_count == 101278
+    assert learner.collector_envstep == 101278
+
+
+def test_restore_resume_counters_keeps_fresh_run_at_zero():
+    learner = _Learner()
+    collector = _Collector()
+
+    _restore_resume_counters(learner, collector, train_iter=0, envstep=0)
+
+    assert learner._last_iter.value == 0
+    assert collector._total_envstep_count == 0
+    assert learner.collector_envstep == 0
+
+
+def test_resume_requires_replay_warmup_but_fresh_run_keeps_one_batch_threshold():
+    assert _required_replay_transitions(0, batch_size=256, resume_buffer_min_transitions=10000) == 257
+    assert _required_replay_transitions(10023, batch_size=256, resume_buffer_min_transitions=10000) == 10000
+    assert _required_replay_transitions(10023, batch_size=256, resume_buffer_min_transitions=0) == 257
+
+
+def test_resume_replay_warmup_rejects_invalid_configuration():
+    with pytest.raises(ValueError, match='non-negative'):
+        _required_replay_transitions(10, batch_size=256, resume_buffer_min_transitions=-1)

--- a/lzero/entry/train_unizero_segment.py
+++ b/lzero/entry/train_unizero_segment.py
@@ -23,6 +23,45 @@ from .utils import calculate_update_per_collect, random_collect
 
 timer = EasyTimer()
 
+
+def _restore_resume_counters(learner, collector, train_iter: int, envstep: int) -> None:
+    """Restore both owners of the counters persisted in learner checkpoints.
+
+    The collector owns the value used by the serial loop and evaluator, whereas
+    ``BaseLearner`` owns the value written to checkpoints.  If only the collector is
+    restored, a best checkpoint saved during the first post-resume evaluation records
+    ``last_step=0`` and a second preemption silently resets envstep-based schedules.
+    """
+    if train_iter > 0:
+        # BaseLearner.train_iter is a read-only property backed by the CountVar `_last_iter`.
+        learner._last_iter.update(train_iter)
+    if envstep > 0:
+        collector._total_envstep_count = envstep
+        learner.collector_envstep = envstep
+
+
+def _required_replay_transitions(
+        resume_train_iter: int, batch_size: int, resume_buffer_min_transitions: int
+) -> int:
+    """Return the replay population required before learning (re)starts.
+
+    Learner checkpoints do not contain the in-memory game buffer. Updating a mature resumed model as
+    soon as a single batch is available makes the first gradients come from an extremely narrow set of
+    new trajectories. Fresh runs retain the historical one-batch threshold; resumed runs can request
+    a short policy-collection warmup.
+    """
+    if batch_size <= 0:
+        raise ValueError(f'batch_size must be positive, got {batch_size}')
+    if resume_buffer_min_transitions < 0:
+        raise ValueError(
+            f'resume_buffer_min_transitions must be non-negative, got {resume_buffer_min_transitions}'
+        )
+    one_full_batch = batch_size + 1  # Preserve the existing strict ``> batch_size`` condition.
+    if resume_train_iter <= 0:
+        return one_full_batch
+    return max(one_full_batch, resume_buffer_min_transitions)
+
+
 def train_unizero_segment(
         input_cfg: Tuple[dict, dict],
         seed: int = 0,
@@ -86,7 +125,7 @@ def train_unizero_segment(
     policy = create_policy(cfg.policy, model=model, enable_field=['learn', 'collect', 'eval'])
 
     # Load pretrained model if specified
-    resume_train_iter, resume_envstep, resume_optimizer_state = 0, 0, None
+    resume_train_iter, resume_envstep = 0, 0
     if model_path is not None:
         logging.info(f'Loading model from {model_path} begin...')
         checkpoint = torch.load(model_path, map_location=cfg.policy.device)
@@ -96,7 +135,6 @@ def train_unizero_segment(
             # the 'model' and 'target_model' keys itself).
             resume_train_iter = checkpoint.get('last_iter', 0)
             resume_envstep = checkpoint.get('last_step', 0)
-            resume_optimizer_state = checkpoint.get('optimizer_world_model', None)
             policy.learn_mode.load_state_dict(checkpoint)
         else:
             # Raw model weights file.
@@ -117,16 +155,10 @@ def train_unizero_segment(
                           stop_value=cfg.env.stop_value, env=evaluator_env, policy=policy.eval_mode,
                           tb_logger=tb_logger, exp_name=cfg.exp_name, policy_config=policy_config)
 
-    # When resuming from a learner checkpoint, restore the training counters and optimizer state so
+    # When resuming from a learner checkpoint, restore the training counters so
     # that schedules (encoder-clip annealing, eval cadence) and the envstep accounting continue
     # instead of restarting from zero.
-    if resume_train_iter > 0:
-        # BaseLearner.train_iter is a read-only property backed by the CountVar `_last_iter`.
-        learner._last_iter.update(resume_train_iter)
-    if resume_envstep > 0:
-        collector._total_envstep_count = resume_envstep
-    if resume_optimizer_state is not None and hasattr(policy, '_optimizer_world_model'):
-        policy._optimizer_world_model.load_state_dict(resume_optimizer_state)
+    _restore_resume_counters(learner, collector, resume_train_iter, resume_envstep)
 
     # Learner's before_run hook
     learner.call_hook('before_run')
@@ -139,6 +171,16 @@ def train_unizero_segment(
         random_collect(cfg.policy, policy, LightZeroRandomPolicy, collector, collector_env, replay_buffer)
 
     batch_size = policy._cfg.batch_size
+    required_replay_transitions = _required_replay_transitions(
+        resume_train_iter,
+        batch_size,
+        int(getattr(cfg.policy, 'resume_buffer_min_transitions', 0)),
+    )
+    if resume_train_iter > 0 and required_replay_transitions > batch_size + 1:
+        logging.info(
+            'Resume replay warmup: collect at least %d transitions before learner updates.',
+            required_replay_transitions,
+        )
 
     # TODO: for visualize
     # stop, reward = evaluator.eval(learner.save_checkpoint, learner.train_iter, collector.envstep)
@@ -217,10 +259,14 @@ def train_unizero_segment(
                 data_sufficient = replay_buffer.get_num_of_game_segments() > batch_size
             else:
                 data_sufficient = replay_buffer.get_num_of_transitions() > batch_size
+            data_sufficient = data_sufficient and (
+                replay_buffer.get_num_of_transitions() >= required_replay_transitions
+            )
             if not data_sufficient:
                 logging.warning(
                     f'The data in replay_buffer is not sufficient to sample a mini-batch: '
-                    f'batch_size: {batch_size}, replay_buffer: {replay_buffer}. Continue to collect now ....'
+                    f'batch_size: {batch_size}, required_transitions: {required_replay_transitions}, '
+                    f'replay_buffer: {replay_buffer}. Continue to collect now ....'
                 )
                 continue
 

--- a/lzero/mcts/ctree/ctree_muzero/lib/cnode.cpp
+++ b/lzero/mcts/ctree/ctree_muzero/lib/cnode.cpp
@@ -548,7 +548,7 @@ namespace tree
         }
     }
 
-    int cselect_child(CNode *root, tools::CMinMaxStats &min_max_stats, int pb_c_base, float pb_c_init, float discount_factor, float mean_q, int players)
+    int cselect_child(CNode *root, tools::CMinMaxStats &min_max_stats, int pb_c_base, float pb_c_init, float discount_factor, float mean_q, int players, bool deterministic)
     {
         /*
         Overview:
@@ -589,8 +589,7 @@ namespace tree
         int action = 0;
         if (max_index_lst.size() > 0)
         {
-            int rand_index = rand() % max_index_lst.size();
-            action = max_index_lst[rand_index];
+            action = deterministic ? max_index_lst.front() : max_index_lst[rand() % max_index_lst.size()];
         }
         return action;
     }
@@ -752,7 +751,7 @@ namespace tree
         return ucb_value;
     }
 
-    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &virtual_to_play_batch)
+    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &virtual_to_play_batch, bool deterministic)
     {
         /*
         Overview:
@@ -766,8 +765,10 @@ namespace tree
             - results: the search results.
             - virtual_to_play_batch: the batch of which player is playing on this node.
         */
-        // set seed
-        get_time_and_set_rand_seed();
+        // Collection preserves stochastic tie-breaking. Evaluation requests deterministic
+        // selection and must not depend on wall-clock microseconds.
+        if (!deterministic)
+            get_time_and_set_rand_seed();
 
         int last_action = -1;
         results.search_lens = std::vector<int>();
@@ -793,7 +794,7 @@ namespace tree
                 is_root = 0;
                 parent_q = mean_q;
 
-                int action = cselect_child(node, min_max_stats_lst->stats_lst[i], pb_c_base, pb_c_init, discount_factor, mean_q, players);
+                int action = cselect_child(node, min_max_stats_lst->stats_lst[i], pb_c_base, pb_c_init, discount_factor, mean_q, players, deterministic);
                 if (players > 1)
                 {
                     assert(virtual_to_play_batch[i] == 1 || virtual_to_play_batch[i] == 2);
@@ -874,7 +875,10 @@ namespace tree
                 }
                 else
                 {
-                    action = cselect_child(node, min_max_stats_lst->stats_lst[i], pb_c_base, pb_c_init, discount_factor, mean_q, players);
+                    action = cselect_child(
+                        node, min_max_stats_lst->stats_lst[i], pb_c_base, pb_c_init,
+                        discount_factor, mean_q, players, false
+                    );
                 }
                 
                 if (players > 1)

--- a/lzero/mcts/ctree/ctree_muzero/lib/cnode.h
+++ b/lzero/mcts/ctree/ctree_muzero/lib/cnode.h
@@ -84,11 +84,11 @@ namespace tree {
     void cbackpropagate(std::vector<CNode*> &search_path, tools::CMinMaxStats &min_max_stats, int to_play, float value, float discount_factor);
     void cbatch_backpropagate(int current_latent_state_index, float discount_factor, const std::vector<float> &rewards, const std::vector<float> &values, const std::vector<std::vector<float> > &policies, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &to_play_batch);
     void cbatch_backpropagate_with_reuse(int current_latent_state_index, float discount_factor, const std::vector<float> &value_prefixs, const std::vector<float> &values, const std::vector<std::vector<float> > &policies, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &to_play_batch, std::vector<int> &no_inference_lst, std::vector<int> &reuse_lst, std::vector<int> &reuse_value_lst);
-    int cselect_child(CNode* root, tools::CMinMaxStats &min_max_stats, int pb_c_base, float pb_c_init, float discount_factor, float mean_q, int players);
+    int cselect_child(CNode* root, tools::CMinMaxStats &min_max_stats, int pb_c_base, float pb_c_init, float discount_factor, float mean_q, int players, bool deterministic);
     int cselect_root_child(CNode *root, tools::CMinMaxStats &min_max_stats, int pb_c_base, float pb_c_init, float discount_factor, float mean_q, int players, int true_action, float reuse_value);
     float cucb_score(CNode *child, tools::CMinMaxStats &min_max_stats, float parent_mean_q, float total_children_visit_counts, float pb_c_base, float pb_c_init, float discount_factor, int players);
     float carm_score(CNode *child, tools::CMinMaxStats &min_max_stats, float parent_mean_q, float reuse_value, float total_children_visit_counts, float pb_c_base, float pb_c_init, float discount_factor, int players);
-    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &virtual_to_play_batch);
+    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &virtual_to_play_batch, bool deterministic);
     void cbatch_traverse_with_reuse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, tools::CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, std::vector<int> &virtual_to_play_batch, std::vector<int> &true_action, std::vector<float> &reuse_value);
 }
 

--- a/lzero/mcts/ctree/ctree_muzero/mz_tree.pxd
+++ b/lzero/mcts/ctree/ctree_muzero/mz_tree.pxd
@@ -1,5 +1,6 @@
 # distutils:language=c++
 # cython:language_level=3
+from libcpp cimport bool
 from libcpp.vector cimport vector
 
 
@@ -72,5 +73,5 @@ cdef extern from "lib/cnode.h" namespace "tree":
                                CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, vector[int] &to_play_batch)
     void cbatch_backpropagate_with_reuse(int current_latent_state_index, float discount_factor, vector[float] value_prefixs, vector[float] values, vector[vector[float]] policies,
                                CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, vector[int] &to_play_batch, vector[int] &no_inference_lst, vector[int] &reuse_lst, vector[float] &reuse_value_lst)
-    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, vector[int] &virtual_to_play_batch)
+    void cbatch_traverse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, vector[int] &virtual_to_play_batch, bool deterministic)
     void cbatch_traverse_with_reuse(CRoots *roots, int pb_c_base, float pb_c_init, float discount_factor, CMinMaxStatsList *min_max_stats_lst, CSearchResults &results, vector[int] &virtual_to_play_batch, vector[int] &true_action, vector[float] &reuse_value)

--- a/lzero/mcts/ctree/ctree_muzero/mz_tree.pyx
+++ b/lzero/mcts/ctree/ctree_muzero/mz_tree.pyx
@@ -93,9 +93,9 @@ def batch_backpropagate_with_reuse(int current_latent_state_index, float discoun
                           min_max_stats_lst.cmin_max_stats_lst, results.cresults, to_play_batch, no_inference_lst, reuse_lst, creuse_value_lst)
 
 def batch_traverse(Roots roots, int pb_c_base, float pb_c_init, float discount_factor, MinMaxStatsList min_max_stats_lst,
-                   ResultsWrapper results, list virtual_to_play_batch):
+                   ResultsWrapper results, list virtual_to_play_batch, bint deterministic=False):
     cbatch_traverse(roots.roots, pb_c_base, pb_c_init, discount_factor, min_max_stats_lst.cmin_max_stats_lst, results.cresults,
-                    virtual_to_play_batch)
+                    virtual_to_play_batch, deterministic)
 
     return results.cresults.latent_state_index_in_search_path, results.cresults.latent_state_index_in_batch, results.cresults.last_actions, results.cresults.virtual_to_play_batchs
 

--- a/lzero/mcts/tests/test_muzero_ctree_deterministic.py
+++ b/lzero/mcts/tests/test_muzero_ctree_deterministic.py
@@ -1,0 +1,48 @@
+from lzero.mcts.ctree.ctree_muzero import mz_tree
+
+
+def test_deterministic_traverse_uses_stable_first_action_for_equal_ucb_scores():
+    roots = mz_tree.Roots(1, [[0, 1, 2]])
+    roots.prepare_no_noise([0.0], [[0.0, 0.0, 0.0]], [-1])
+    min_max_stats = mz_tree.MinMaxStatsList(1)
+    min_max_stats.set_delta(0.01)
+
+    selected_actions = []
+    for _ in range(5):
+        results = mz_tree.ResultsWrapper(1)
+        traversal = mz_tree.batch_traverse(
+            roots,
+            19652,
+            1.25,
+            0.997,
+            min_max_stats,
+            results,
+            [-1],
+            deterministic=True,
+        )
+        selected_actions.append(traversal[2][0])
+
+    assert selected_actions == [0] * 5
+
+
+def test_default_traverse_preserves_stochastic_tie_breaking():
+    roots = mz_tree.Roots(1, [[0, 1, 2]])
+    roots.prepare_no_noise([0.0], [[0.0, 0.0, 0.0]], [-1])
+    min_max_stats = mz_tree.MinMaxStatsList(1)
+    min_max_stats.set_delta(0.01)
+
+    selected_actions = []
+    for _ in range(30):
+        results = mz_tree.ResultsWrapper(1)
+        traversal = mz_tree.batch_traverse(
+            roots,
+            19652,
+            1.25,
+            0.997,
+            min_max_stats,
+            results,
+            [-1],
+        )
+        selected_actions.append(traversal[2][0])
+
+    assert len(set(selected_actions)) > 1

--- a/lzero/mcts/tree_search/mcts_ctree.py
+++ b/lzero/mcts/tree_search/mcts_ctree.py
@@ -37,6 +37,8 @@ class UniZeroMCTSCtree(object):
         # (float) The maximum change in value allowed during the backup step of the search tree update.
         value_delta_max=0.01,
         env_type='not_board_games',
+        # Keep collection tie-breaking stochastic; policy eval overrides this to True.
+        deterministic=False,
     )
 
     @classmethod
@@ -125,12 +127,12 @@ class UniZeroMCTSCtree(object):
                 if self._cfg.env_type == 'not_board_games':
                     latent_state_index_in_search_path, latent_state_index_in_batch, last_actions, virtual_to_play_batch = tree_muzero.batch_traverse(
                         roots, pb_c_base, pb_c_init, discount_factor, min_max_stats_lst, results,
-                        to_play_batch
+                        to_play_batch, self._cfg.deterministic
                     )
                 else:
                     latent_state_index_in_search_path, latent_state_index_in_batch, last_actions, virtual_to_play_batch = tree_muzero.batch_traverse(
                         roots, pb_c_base, pb_c_init, discount_factor, min_max_stats_lst, results,
-                        copy.deepcopy(to_play_batch)
+                        copy.deepcopy(to_play_batch), self._cfg.deterministic
                     )
 
                 # obtain the latent state for leaf node

--- a/lzero/policy/tests/test_unizero_checkpoint_state.py
+++ b/lzero/policy/tests/test_unizero_checkpoint_state.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from lzero.policy.unizero import UniZeroPolicy
+
+
+def _minimal_policy(alpha: float, legacy_resume_alpha=None) -> UniZeroPolicy:
+    policy = object.__new__(UniZeroPolicy)
+    policy._cfg = SimpleNamespace(
+        model=SimpleNamespace(analysis_sim_norm=False),
+        legacy_resume_adaptive_alpha=legacy_resume_alpha,
+    )
+    policy._learn_model = torch.nn.Linear(2, 2)
+    policy._target_model = torch.nn.Linear(2, 2)
+    policy._optimizer_world_model = torch.optim.Adam(policy._learn_model.parameters(), lr=1e-3)
+    policy.use_adaptive_entropy_weight = True
+    policy.log_alpha = torch.nn.Parameter(torch.tensor([alpha]).log())
+    policy.alpha_optimizer = torch.optim.Adam([policy.log_alpha], lr=1e-3)
+    return policy
+
+
+def _populate_optimizer_state(policy: UniZeroPolicy) -> None:
+    policy._learn_model(torch.ones(1, 2)).sum().backward()
+    policy._optimizer_world_model.step()
+    policy.alpha_optimizer.zero_grad()
+    policy.log_alpha.sum().backward()
+    policy.alpha_optimizer.step()
+
+
+def test_unizero_checkpoint_round_trip_restores_adaptive_entropy_and_optimizers():
+    source = _minimal_policy(alpha=0.23)
+    _populate_optimizer_state(source)
+    checkpoint = source._state_dict_learn()
+
+    restored = _minimal_policy(alpha=1.0)
+    restored._load_state_dict_learn(checkpoint)
+
+    assert restored.log_alpha.exp().item() == pytest.approx(source.log_alpha.exp().item())
+    assert restored._optimizer_world_model.state_dict()['state']
+    assert restored.alpha_optimizer.state_dict()['state']
+
+
+def test_legacy_checkpoint_can_restore_alpha_from_explicit_log_value():
+    source = _minimal_policy(alpha=0.23)
+    checkpoint = source._state_dict_learn()
+    checkpoint.pop('log_alpha')
+
+    restored = _minimal_policy(alpha=1.0, legacy_resume_alpha=0.23)
+    restored._load_state_dict_learn(checkpoint)
+
+    assert restored.log_alpha.exp().item() == pytest.approx(0.23)

--- a/lzero/policy/tests/test_unizero_representation_health.py
+++ b/lzero/policy/tests/test_unizero_representation_health.py
@@ -1,0 +1,49 @@
+import pytest
+import torch
+
+from lzero.policy.unizero import (
+    replay_distribution_metrics,
+    representation_health_metrics,
+    should_run_periodic_monitor,
+)
+
+
+def test_representation_health_detects_collapse_even_when_token_norms_match():
+    collapsed = torch.tensor([[[1.0, 0.0]], [[1.0, 0.0]]])
+    diverse = torch.tensor([[[1.0, 0.0]], [[0.0, 1.0]]])
+
+    # Both populations have identical per-token L2 norms, so the old metric is
+    # zero for both and cannot distinguish healthy diversity from collapse.
+    assert collapsed.norm(dim=-1).std().item() == pytest.approx(0.0)
+    assert diverse.norm(dim=-1).std().item() == pytest.approx(0.0)
+
+    collapsed_metrics = representation_health_metrics(collapsed)
+    diverse_metrics = representation_health_metrics(diverse)
+
+    assert collapsed_metrics['activation/x_token/feature_std_mean'] == pytest.approx(0.0)
+    assert collapsed_metrics['activation/x_token/near_constant_fraction'] == pytest.approx(1.0)
+    assert diverse_metrics['activation/x_token/feature_std_mean'] == pytest.approx(0.5)
+    assert diverse_metrics['activation/x_token/near_constant_fraction'] == pytest.approx(0.0)
+
+
+def test_representation_health_rejects_missing_feature_dimension():
+    with pytest.raises(ValueError, match='Expected'):
+        representation_health_metrics(torch.tensor(1.0))
+
+
+def test_periodic_monitor_runs_immediately_after_resume_then_on_boundaries():
+    assert should_run_periodic_monitor(train_iter=10023, frequency=10000, last_check_iter=-1)
+    assert not should_run_periodic_monitor(train_iter=10024, frequency=10000, last_check_iter=10023)
+    assert should_run_periodic_monitor(train_iter=20000, frequency=10000, last_check_iter=10023)
+    assert not should_run_periodic_monitor(train_iter=20000, frequency=0, last_check_iter=-1)
+
+
+def test_replay_distribution_metrics_expose_effective_sample_size():
+    uniform = replay_distribution_metrics(torch.ones(4), torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    skewed = replay_distribution_metrics(torch.tensor([1.0, 0.1, 0.1, 0.1]), torch.ones(4))
+
+    assert uniform['replay/is_weight_mean'] == pytest.approx(1.0)
+    assert uniform['replay/is_weight_std'] == pytest.approx(0.0)
+    assert uniform['replay/is_weight_ess_fraction'] == pytest.approx(1.0)
+    assert uniform['replay/value_priority_std'] == pytest.approx(1.11803399)
+    assert skewed['replay/is_weight_ess_fraction'] < 0.5

--- a/lzero/policy/unizero.py
+++ b/lzero/policy/unizero.py
@@ -25,6 +25,56 @@ from torch.nn.utils.convert_parameters import (parameters_to_vector,
 from .utils import configure_optimizers_nanogpt
 
 
+def representation_health_metrics(x: torch.Tensor, near_constant_threshold: float = 1e-3) -> Dict[str, float]:
+    """Measure representation diversity across samples/tokens, per feature.
+
+    The standard deviation of token L2 norms is not a collapse metric after
+    LayerNorm: every token is expected to have norm close to ``sqrt(embed_dim)``.
+    Collapse instead means that individual feature coordinates stop varying
+    across the batch/time population.
+    """
+    if x.ndim < 2 or x.shape[-1] == 0:
+        raise ValueError(f"Expected [..., feature_dim] tensor, got shape {tuple(x.shape)}")
+    flattened = x.detach().float().reshape(-1, x.shape[-1])
+    feature_std = flattened.std(dim=0, unbiased=False)
+    return {
+        'activation/x_token/feature_std_mean': feature_std.mean().item(),
+        'activation/x_token/feature_std_min': feature_std.min().item(),
+        'activation/x_token/near_constant_fraction': (feature_std < near_constant_threshold).float().mean().item(),
+    }
+
+
+def should_run_periodic_monitor(train_iter: int, frequency: int, last_check_iter: int) -> bool:
+    """Run once after policy construction/resume, then at configured iteration boundaries."""
+    return frequency > 0 and (last_check_iter < 0 or train_iter % frequency == 0)
+
+
+def replay_distribution_metrics(weights: torch.Tensor, value_priority: torch.Tensor) -> Dict[str, float]:
+    """Summarize PER importance weights and TD-error priorities without changing training.
+
+    The normalized effective sample size (ESS) distinguishes a genuinely diverse, well-corrected
+    prioritized batch from one whose gradient is dominated by a small number of samples.  Uniform
+    replay should produce unit weights and ``ess_fraction=1``.
+    """
+    weights_flat = weights.detach().float().reshape(-1)
+    priority_flat = value_priority.detach().float().reshape(-1)
+    if weights_flat.numel() == 0 or priority_flat.numel() == 0:
+        raise ValueError('Replay diagnostics require non-empty weights and value priorities')
+    weight_square_sum = weights_flat.square().sum().clamp_min(torch.finfo(weights_flat.dtype).tiny)
+    ess_fraction = weights_flat.sum().square() / (weights_flat.numel() * weight_square_sum)
+    return {
+        'replay/is_weight_mean': weights_flat.mean().item(),
+        'replay/is_weight_std': weights_flat.std(unbiased=False).item(),
+        'replay/is_weight_min': weights_flat.min().item(),
+        'replay/is_weight_max': weights_flat.max().item(),
+        'replay/is_weight_ess_fraction': ess_fraction.item(),
+        'replay/value_priority_mean': priority_flat.mean().item(),
+        'replay/value_priority_std': priority_flat.std(unbiased=False).item(),
+        'replay/value_priority_min': priority_flat.min().item(),
+        'replay/value_priority_max': priority_flat.max().item(),
+    }
+
+
 def scale_module_weights_vectorized(module: torch.nn.Module, scale_factor: float):
     """
     Efficiently scale all weights of a module using vectorized operations.
@@ -329,6 +379,9 @@ class UniZeroPolicy(MuZeroPolicy):
         use_adaptive_entropy_weight=False,
         # (float) Learning rate for adaptive alpha optimizer
         adaptive_entropy_alpha_lr=1e-3,
+        # (float or None) Explicit alpha for legacy checkpoints that did not persist log_alpha.
+        # Ignored whenever the checkpoint contains an exact log_alpha value.
+        legacy_resume_adaptive_alpha=None,
         # (float) Lower/upper bounds for adaptive entropy alpha. The lower bound must stay well below
         # typical Atari entropy weights so alpha can keep decaying when the target entropy anneals.
         adaptive_entropy_alpha_min=1e-4,
@@ -559,6 +612,10 @@ class UniZeroPolicy(MuZeroPolicy):
         # ****** Explore by random collect ******
         # (int) The number of episodes to collect data randomly before training.
         random_collect_episode_num=0,
+        # (int) Learner checkpoints do not persist the in-memory replay buffer. On resume, collect
+        # this many on-policy transitions before applying gradients to avoid a one-batch distribution shock.
+        # Zero preserves the historical one-batch threshold; large-buffer tasks can opt in explicitly.
+        resume_buffer_min_transitions=0,
 
         # ****** Explore by eps greedy ******
         eps=dict(
@@ -754,6 +811,10 @@ class UniZeroPolicy(MuZeroPolicy):
         self.l2_norm_after = 0.
         self.grad_norm_before = 0.
         self.grad_norm_after = 0.
+        # Sparse stability checks must not appear as zero in every intervening learner log.
+        # Cache the last real observation, and force a check on the first batch after resume.
+        self._latest_norm_log_dict = {}
+        self._last_norm_monitor_iter = -1
 
         if self._cfg.model.model_type == 'conv':
             # for image-input env
@@ -987,8 +1048,11 @@ class UniZeroPolicy(MuZeroPolicy):
 
         # ==================== Integrate norm monitoring logic ====================
         norm_log_dict = {}
+        should_monitor_norms = should_run_periodic_monitor(
+            train_iter, self._cfg.monitor_norm_freq, self._last_norm_monitor_iter
+        )
         # Check if monitoring frequency is reached
-        if self._cfg.monitor_norm_freq > 0 and (train_iter == 0 or (train_iter % self._cfg.monitor_norm_freq == 0)):
+        if should_monitor_norms:
             with torch.no_grad():
                 # 1. Monitor model parameter norms
                 param_norm_metrics = self._monitor_model_norms()
@@ -1006,6 +1070,7 @@ class UniZeroPolicy(MuZeroPolicy):
                     norm_log_dict['norm/x_token/std'] = token_norms.std().item()
                     norm_log_dict['norm/x_token/max'] = token_norms.max().item()
                     norm_log_dict['norm/x_token/min'] = token_norms.min().item()
+                    norm_log_dict.update(representation_health_metrics(intermediate_x))
 
                 # 3. Monitor detailed statistics of logits (Value, Policy, Reward)
                 logits_value = losses.intermediate_losses.get('logits_value')
@@ -1062,13 +1127,23 @@ class UniZeroPolicy(MuZeroPolicy):
                     elif emb_norm_std > 5.0:
                         warnings_issued.append(f"⚠️ WARNING: Embedding norm std increasing! std={emb_norm_std:.2f} (threshold: 5.0)")
 
-                # Check 3: X token norm collapse
-                if 'norm/x_token/std' in norm_log_dict:
-                    x_token_std = norm_log_dict['norm/x_token/std']
-                    if x_token_std < 0.1:
-                        warnings_issued.append(f"⚠️ CRITICAL: X token norm collapse! std={x_token_std:.4f} (threshold: 0.1)")
-                    elif x_token_std < 0.5:
-                        warnings_issued.append(f"⚠️ WARNING: X token norm decreasing! std={x_token_std:.4f} (threshold: 0.5)")
+                # Check 3: representation collapse. Token-norm std is not used:
+                # LayerNorm intentionally makes all token L2 norms nearly equal.
+                if 'activation/x_token/feature_std_mean' in norm_log_dict:
+                    feature_std_mean = norm_log_dict['activation/x_token/feature_std_mean']
+                    near_constant_fraction = norm_log_dict['activation/x_token/near_constant_fraction']
+                    if feature_std_mean < 1e-3 or near_constant_fraction > 0.99:
+                        warnings_issued.append(
+                            "⚠️ CRITICAL: X token representation collapse! "
+                            f"feature_std_mean={feature_std_mean:.4g}, "
+                            f"near_constant_fraction={near_constant_fraction:.2%}"
+                        )
+                    elif feature_std_mean < 1e-2 or near_constant_fraction > 0.9:
+                        warnings_issued.append(
+                            "⚠️ WARNING: X token feature diversity is low! "
+                            f"feature_std_mean={feature_std_mean:.4g}, "
+                            f"near_constant_fraction={near_constant_fraction:.2%}"
+                        )
 
                 # Log warnings if any
                 if warnings_issued:
@@ -1083,6 +1158,7 @@ class UniZeroPolicy(MuZeroPolicy):
         value_priority_tensor = losses.intermediate_losses['value_priority']
         # Convert to numpy array for the replay buffer, adding a small epsilon.
         value_priority_np = value_priority_tensor.detach().cpu().numpy() + 1e-6
+        replay_log_dict = replay_distribution_metrics(weights, value_priority_tensor)
 
         # ==================== START: PER importance-sampling weighting ====================
         # NOTE: losses.loss_total is a batch-level scalar, so ``(weights * losses.loss_total).mean()``
@@ -1241,7 +1317,7 @@ class UniZeroPolicy(MuZeroPolicy):
         if (train_iter + 1) % self.accumulation_steps == 0:
             # ==================== [NEW] Monitor gradient norms ====================
             # Monitor gradient norms before gradient clipping to diagnose gradient explosion/vanishing issues
-            if self._cfg.monitor_norm_freq > 0 and (train_iter == 0 or (train_iter % self._cfg.monitor_norm_freq == 0)):
+            if should_monitor_norms:
                 grad_norm_metrics = self._monitor_gradient_norms()
                 norm_log_dict.update(grad_norm_metrics)
             # =================================================================
@@ -1374,9 +1450,14 @@ class UniZeroPolicy(MuZeroPolicy):
             'collect/mcts_temperature': self._collect_mcts_temperature,
             'schedule/policy_label_eps': current_policy_label_eps,
         })
+        return_log_dict.update(replay_log_dict)
 
-        if norm_log_dict:
-            return_log_dict.update(norm_log_dict)
+        if should_monitor_norms:
+            norm_log_dict['stability/last_check_iter'] = float(train_iter)
+            self._latest_norm_log_dict = norm_log_dict.copy()
+            self._last_norm_monitor_iter = train_iter
+        if self._latest_norm_log_dict:
+            return_log_dict.update(self._latest_norm_log_dict)
 
         use_enhanced_policy_monitoring = self._cfg.use_enhanced_policy_monitoring
         if use_enhanced_policy_monitoring:
@@ -1673,6 +1754,7 @@ class UniZeroPolicy(MuZeroPolicy):
         # Create a configuration copy for eval MCTS and set specific simulation count
         mcts_eval_cfg = copy.deepcopy(self._cfg)
         mcts_eval_cfg.num_simulations = self._cfg.eval_num_simulations
+        mcts_eval_cfg.deterministic = True
 
         if self._cfg.mcts_ctree:
             self._mcts_eval = MCTSCtree(mcts_eval_cfg)
@@ -2051,6 +2133,17 @@ class UniZeroPolicy(MuZeroPolicy):
             'adaptive_target_entropy_ratio',
             'alpha_loss',
             'current_encoder_clip_value',
+
+            # ==================== Replay / PER Diagnostics ====================
+            'replay/is_weight_mean',
+            'replay/is_weight_std',
+            'replay/is_weight_min',
+            'replay/is_weight_max',
+            'replay/is_weight_ess_fraction',
+            'replay/value_priority_mean',
+            'replay/value_priority_std',
+            'replay/value_priority_min',
+            'replay/value_priority_max',
         ]
 
         # ==================== [NEW] Norm and Intermediate Tensor Monitoring Variables ====================
@@ -2074,6 +2167,9 @@ class UniZeroPolicy(MuZeroPolicy):
             'norm/x_token/std',
             'norm/x_token/max',
             'norm/x_token/min',
+            'activation/x_token/feature_std_mean',
+            'activation/x_token/feature_std_min',
+            'activation/x_token/near_constant_fraction',
 
             # Detailed logits statistics (Value)
             'logits/value/mean',
@@ -2129,6 +2225,7 @@ class UniZeroPolicy(MuZeroPolicy):
 
         stability_vars = [
             'stability/warning_count',  # Number of warnings issued in current check
+            'stability/last_check_iter',  # Iteration that produced the cached stability metrics
         ]
 
         return base_vars + norm_vars+ head_clip_vars + enhanced_policy_vars + stability_vars
@@ -2148,6 +2245,7 @@ class UniZeroPolicy(MuZeroPolicy):
         }
         # ==================== START: Save Alpha Optimizer State ====================
         if self.use_adaptive_entropy_weight:
+            state_dict['log_alpha'] = self.log_alpha.detach().clone()
             state_dict['alpha_optimizer'] = self.alpha_optimizer.state_dict()
         # ===================== END: Save Alpha Optimizer State =====================
         return state_dict
@@ -2161,6 +2259,31 @@ class UniZeroPolicy(MuZeroPolicy):
         """
         self._learn_model.load_state_dict(state_dict['model'])
         self._target_model.load_state_dict(state_dict['target_model'])
+        if 'optimizer_world_model' in state_dict:
+            self._optimizer_world_model.load_state_dict(state_dict['optimizer_world_model'])
+        if self.use_adaptive_entropy_weight:
+            if 'log_alpha' in state_dict:
+                with torch.no_grad():
+                    self.log_alpha.copy_(state_dict['log_alpha'].to(self.log_alpha.device))
+            else:
+                legacy_alpha = getattr(self._cfg, 'legacy_resume_adaptive_alpha', None)
+                if legacy_alpha is not None:
+                    legacy_alpha = float(legacy_alpha)
+                    if legacy_alpha <= 0:
+                        raise ValueError('legacy_resume_adaptive_alpha must be positive')
+                    with torch.no_grad():
+                        self.log_alpha.fill_(np.log(legacy_alpha))
+                    logging.warning('Restored explicit legacy adaptive alpha=%.6g.', legacy_alpha)
+                else:
+                    logging.warning(
+                        'Adaptive-entropy checkpoint has no log_alpha; keeping initialized alpha=%.6g. '
+                        'Set legacy_resume_adaptive_alpha to restore a value recorded in external logs.',
+                        self.log_alpha.exp().item(),
+                    )
+            if 'alpha_optimizer' in state_dict:
+                self.alpha_optimizer.load_state_dict(state_dict['alpha_optimizer'])
+            else:
+                logging.warning('Adaptive-entropy checkpoint has no alpha_optimizer state.')
 
     def recompute_pos_emb_diff_and_clear_cache(self) -> None:
         """

--- a/zoo/atari/config/atari_unizero_segment_config.py
+++ b/zoo/atari/config/atari_unizero_segment_config.py
@@ -57,6 +57,11 @@ def main(
         disable_policy_label_smoothing=True,
         resume_from=None,
         max_env_step_override=None,
+        use_priority=None,
+        stab_fix=False,
+        game_segment_length_override=None,
+        save_ckpt_after_iter_override=None,
+        legacy_resume_alpha=None,
 ):
     action_space_size = atari_env_action_space_map[env_id]
 
@@ -65,12 +70,19 @@ def main(
     # ==============================================================
     collector_env_num = 8
     num_segments = 8
-    evaluator_env_num = 3
+    evaluator_env_num = 8  # 3->8: reduce eval reward_mean noise for attribution (takes effect on next run restart)
 
     # game_segment_length=20 makes only 20-(num_unroll_steps+td_steps)=5 of the 20 positions in each
     # non-terminal segment eligible as sampling roots (valid_len in game_buffer._push_game_segment),
     # i.e. 75% of the collected transitions can never be trained on. 200 restores ~92.5% coverage.
-    game_segment_length = 200
+    game_segment_length = 200 if game_segment_length_override is None else int(game_segment_length_override)
+    save_ckpt_after_iter = (
+        50000 if save_ckpt_after_iter_override is None else int(save_ckpt_after_iter_override)
+    )
+    if save_ckpt_after_iter <= 0:
+        raise ValueError(f'save_ckpt_after_iter must be positive, got {save_ckpt_after_iter}')
+    if legacy_resume_alpha is not None and legacy_resume_alpha <= 0:
+        raise ValueError(f'legacy_resume_alpha must be positive, got {legacy_resume_alpha}')
     num_unroll_steps = 10
     infer_context_length = 4
 
@@ -144,6 +156,12 @@ def main(
                     use_normal_head=True,
                     optim_type='AdamW_mix_lr_wdecay',
                     use_new_cache_manager=use_new_cache_manager,
+                    # Policy-stability protections (500K crash chain: extreme target_policy ->
+                    # logits explosion -> x_token collapse). Off by default; --stab-fix enables.
+                    use_policy_logits_clip=stab_fix,
+                    policy_logits_clip_method='soft_tanh',
+                    policy_logits_clip_min=-10.0,
+                    policy_logits_clip_max=10.0,
                 ),
             ),
             # Learning settings
@@ -155,6 +173,9 @@ def main(
             num_unroll_steps=num_unroll_steps,
             num_segments=num_segments,
             game_segment_length=game_segment_length,
+            # Full learner checkpoints are ~530MB each; save every 50k train iters instead of
+            # the default 10k to bound disk usage. ckpt_best (on new best eval) is unaffected.
+            learn=dict(learner=dict(hook=dict(save_ckpt_after_iter=save_ckpt_after_iter))),
             # KV caches are cleared once per env per this many env steps. Was hardcoded to
             # game_segment_length, which wiped all MCTS kv caches after every single segment.
             kv_cache_clear_interval=2000,
@@ -165,6 +186,7 @@ def main(
             # Adaptive target entropy settings from the 2025 Pong run.
             use_adaptive_entropy_weight=not disable_adaptive_alpha,
             adaptive_entropy_alpha_lr=1e-4,
+            legacy_resume_adaptive_alpha=legacy_resume_alpha,
             target_entropy_start_ratio=0.98,
             target_entropy_end_ratio=0.7,
             target_entropy_decay_steps=100000,
@@ -187,8 +209,13 @@ def main(
             policy_ls_eps_end=0.0 if disable_policy_label_smoothing else 0.01,
             policy_ls_eps_decay_steps=50000,
             label_smoothing_eps=0.1,
-            use_continuous_label_smoothing=False,
+            use_continuous_label_smoothing=stab_fix,
+            continuous_ls_eps=0.05,
             monitor_norm_freq=10000,
+            # Always-on enhanced policy monitoring: without this flag the whitelisted
+            # policy_logits/* and target_policy_entropy/{mean,min,max,std} log keys print
+            # constant 0.0 (empty-record averaging), hiding real logits/entropy stats.
+            use_enhanced_policy_monitoring=True,
 
             # Priority settings.
             # Default ON. A 2026-08-06 Pong A/B suggested PER-off learned faster in the first
@@ -198,7 +225,7 @@ def main(
             # value_priority tensor is computed and update_priority() stays shape-compatible;
             # setting use_priority=False here switches the buffer to uniform sampling and
             # priority write-backs are then discarded.
-            use_priority=True,
+            use_priority=True if use_priority is None else use_priority,
             priority_prob_alpha=0.6,
             priority_prob_beta=0.4,
 
@@ -212,6 +239,9 @@ def main(
             evaluator_env_num=evaluator_env_num,
             eval_freq=int(5e3),
             replay_buffer_size=int(5e5),
+            # Policy checkpoints omit the ~25GB full Atari replay buffer. Refill a small diverse
+            # on-policy window before updating a mature model after preemption.
+            resume_buffer_min_transitions=10000,
         ),
     )
     atari_unizero_config = EasyDict(atari_unizero_config)
@@ -316,6 +346,33 @@ if __name__ == "__main__":
         '--max-env-step', dest='max_env_step', type=int, default=None,
         help='Override the default max env-step budget (e.g. for continuing a run past its cap).'
     )
+    priority_group = parser.add_mutually_exclusive_group()
+    priority_group.add_argument(
+        '--use-priority', dest='use_priority', action='store_true',
+        help='Force prioritized replay on (this is the default).'
+    )
+    priority_group.add_argument(
+        '--no-priority', dest='use_priority', action='store_false',
+        help='Disable prioritized replay (uniform sampling) for ablations.'
+    )
+    parser.set_defaults(use_priority=None)
+    parser.add_argument(
+        '--stab-fix', dest='stab_fix', action='store_true',
+        help='Enable policy-stability protections (soft_tanh policy-logits clip +-10 + '
+             'continuous label smoothing eps=0.05) from the 500K-crash fix bundle.'
+    )
+    parser.add_argument(
+        '--game-segment-length', dest='game_segment_length', type=int, default=None,
+        help='Override game_segment_length (default 200; the 2025-10 known-good Pong run used 20).'
+    )
+    parser.add_argument(
+        '--save-ckpt-after-iter', dest='save_ckpt_after_iter', type=int, default=None,
+        help='Override periodic learner-checkpoint interval; useful on preemptible clusters.'
+    )
+    parser.add_argument(
+        '--legacy-resume-alpha', dest='legacy_resume_alpha', type=float, default=None,
+        help='Adaptive alpha recorded externally for a legacy checkpoint without log_alpha.'
+    )
     args = parser.parse_args()
 
     main(
@@ -329,4 +386,9 @@ if __name__ == "__main__":
         disable_policy_label_smoothing=args.disable_policy_label_smoothing,
         resume_from=args.resume_from,
         max_env_step_override=args.max_env_step,
+        use_priority=args.use_priority,
+        stab_fix=args.stab_fix,
+        game_segment_length_override=args.game_segment_length,
+        save_ckpt_after_iter_override=args.save_ckpt_after_iter,
+        legacy_resume_alpha=args.legacy_resume_alpha,
     )

--- a/zoo/atari/envs/atari_lightzero_env.py
+++ b/zoo/atari/envs/atari_lightzero_env.py
@@ -13,6 +13,18 @@ from easydict import EasyDict
 from zoo.atari.envs.atari_wrappers import wrap_lightzero
 
 
+def _prepare_reset_seed(base_seed: int, dynamic_seed: bool) -> int:
+    """Choose the ALE seed and synchronize randomness used by legacy wrappers.
+
+    ``NoopResetWrapper`` uses NumPy's process-local RNG rather than ALE's RNG.  Without
+    reseeding it, ``dynamic_seed=False`` still produces a different no-op count on every
+    evaluation, so the same checkpoint is not reproducible after a restart.
+    """
+    reset_seed = base_seed + 100 * np.random.randint(1, 1000) if dynamic_seed else base_seed
+    np.random.seed(reset_seed)
+    return int(reset_seed)
+
+
 @ENV_REGISTRY.register('atari_lightzero')
 class AtariEnvLightZero(BaseEnv):
     """
@@ -148,11 +160,9 @@ class AtariEnvLightZero(BaseEnv):
 
             self._init_flag = True
 
-        if hasattr(self, '_seed') and hasattr(self, '_dynamic_seed') and self._dynamic_seed:
-            np_seed = 100 * np.random.randint(1, 1000)
-            self._env.seed(self._seed + np_seed)
-        elif hasattr(self, '_seed'):
-            self._env.seed(self._seed)
+        if hasattr(self, '_seed'):
+            reset_seed = _prepare_reset_seed(self._seed, getattr(self, '_dynamic_seed', True))
+            self._env.seed(reset_seed)
 
         result = self._env.reset()
         if isinstance(result, tuple):

--- a/zoo/atari/envs/atari_wrappers.py
+++ b/zoo/atari/envs/atari_wrappers.py
@@ -7,12 +7,30 @@ import gym  # For legacy API wrapper base class
 import gymnasium  # For creating environments
 import ale_py
 import numpy as np
+from ditk import logging
 from ding.envs import NoopResetWrapper, MaxAndSkipWrapper, EpisodicLifeWrapper, FireResetWrapper, WarpFrameWrapper, \
     ScaledFloatFrameWrapper, \
     ClipRewardWrapper, FrameStackWrapper, TimeLimitWrapper
 from ding.utils.compression_helper import jpeg_data_compressor
 from easydict import EasyDict
 from gymnasium.wrappers import RecordVideo
+
+
+def _atari_make_kwargs(config: EasyDict) -> dict:
+    """Return base ALE kwargs compatible with LightZero's outer frame skip.
+
+    ``ALE/<game>-v5`` defaults to internal frame skip 4 and sticky actions.
+    LightZero repeats actions in ``MaxAndSkipWrapper`` below, so accepting the
+    v5 defaults would turn the historical four-frame control interval into a
+    sixteen-frame interval.  Keep action repeat owned by exactly one layer.
+    """
+    kwargs = {
+        'render_mode': 'human' if config.render_mode_human else 'rgb_array',
+        'full_action_space': config.full_action_space,
+    }
+    if str(config.env_id).startswith('ALE/'):
+        kwargs.update(frameskip=1, repeat_action_probability=0.0)
+    return kwargs
 
 
 def _strip_gymnasium_reset_info(observation):
@@ -128,11 +146,19 @@ def wrap_lightzero(config: EasyDict, episode_life: bool, clip_rewards: bool) -> 
     Return:
         - env (:obj:`gym.Env`): The wrapped Atari environment with the given configurations.
     """
-    # Step 1: Create base environment using gymnasium
-    if config.render_mode_human:
-        env = gymnasium.make(config.env_id, render_mode='human', full_action_space=config.full_action_space)
-    else:
-        env = gymnasium.make(config.env_id, render_mode='rgb_array', full_action_space=config.full_action_space)
+    # Step 1: Create an unskipped deterministic base environment.  The outer
+    # MaxAndSkipWrapper below is the sole owner of action repeat/max-pooling.
+    env = gymnasium.make(config.env_id, **_atari_make_kwargs(config))
+    if str(config.env_id).startswith('ALE/'):
+        actual_kwargs = env.spec.kwargs
+        assert actual_kwargs.get('frameskip') == 1, actual_kwargs
+        assert actual_kwargs.get('repeat_action_probability') == 0.0, actual_kwargs
+        logging.info(
+            "LightZero Atari semantics: env=%s, base_frameskip=1, outer_frameskip=%s, "
+            "repeat_action_probability=0.0",
+            config.env_id,
+            config.frame_skip,
+        )
 
     # (Optional) Apply gymnasium native wrappers
     if hasattr(config, 'save_replay') and config.save_replay \

--- a/zoo/atari/tests/test_atari_reset_seed.py
+++ b/zoo/atari/tests/test_atari_reset_seed.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from zoo.atari.envs.atari_lightzero_env import _prepare_reset_seed
+
+
+def test_static_eval_seed_replays_legacy_noop_rng_sequence():
+    _prepare_reset_seed(base_seed=7, dynamic_seed=False)
+    first_noop_count = np.random.randint(1, 31)
+
+    _prepare_reset_seed(base_seed=7, dynamic_seed=False)
+    second_noop_count = np.random.randint(1, 31)
+
+    assert first_noop_count == second_noop_count
+
+
+def test_dynamic_collect_seed_changes_but_is_reproducible():
+    np.random.seed(123)
+    first_sequence = [_prepare_reset_seed(base_seed=7, dynamic_seed=True) for _ in range(3)]
+
+    np.random.seed(123)
+    second_sequence = [_prepare_reset_seed(base_seed=7, dynamic_seed=True) for _ in range(3)]
+
+    assert first_sequence == second_sequence
+    assert len(set(first_sequence)) > 1

--- a/zoo/atari/tests/test_atari_wrappers.py
+++ b/zoo/atari/tests/test_atari_wrappers.py
@@ -1,0 +1,23 @@
+from easydict import EasyDict
+
+from zoo.atari.envs.atari_wrappers import _atari_make_kwargs
+
+
+def test_ale_v5_base_env_does_not_double_apply_frame_skip_or_sticky_actions():
+    cfg = EasyDict(env_id='ALE/Pong-v5', render_mode_human=False, full_action_space=False)
+
+    assert _atari_make_kwargs(cfg) == {
+        'render_mode': 'rgb_array',
+        'full_action_space': False,
+        'frameskip': 1,
+        'repeat_action_probability': 0.0,
+    }
+
+
+def test_legacy_noframeskip_env_keeps_registry_semantics():
+    cfg = EasyDict(env_id='PongNoFrameskip-v4', render_mode_human=True, full_action_space=True)
+
+    assert _atari_make_kwargs(cfg) == {
+        'render_mode': 'human',
+        'full_action_space': True,
+    }


### PR DESCRIPTION
Avoid double frame skipping and sticky actions with ALE v5. Make evaluation reproducible, preserve complete UniZero resume state, warm replay after resume, and expose stability/PER diagnostics with regression coverage.