### PR TITLE
fix(pu): stabilize MuZero RND KeyCorridor minigrid reproduction

### DIFF
--- a/lzero/entry/train_muzero_with_reward_model.py
+++ b/lzero/entry/train_muzero_with_reward_model.py
@@ -161,11 +161,11 @@ def train_muzero_with_reward_model(
         # update reward_model
         if reward_model.cfg.input_type == 'latent_state':
             # train reward_model with latent_state
-            if len(reward_model.train_latent_state) > reward_model.cfg.batch_size:
+            if len(reward_model.train_latent_state) >= reward_model.cfg.batch_size:
                 reward_model.train_with_data()
-        elif reward_model.cfg.input_type in ['obs', 'latent_state']:
+        elif reward_model.cfg.input_type in ['obs', 'obs_latent_state']:
             # train reward_model with obs
-            if len(reward_model.train_obs) > reward_model.cfg.batch_size:
+            if len(reward_model.train_obs) >= reward_model.cfg.batch_size:
                 reward_model.train_with_data()
         # clear old data in reward_model
         reward_model.clear_old_data()

--- a/lzero/model/common.py
+++ b/lzero/model/common.py
@@ -840,7 +840,10 @@ class RepresentationNetworkMLP(nn.Module):
             - x (:obj:`torch.Tensor`): (B, observation_shape)
             - output (:obj:`torch.Tensor`): (B, hidden_channels)
         """
-        x = self.fc_representation(x)
+        # Vector observations may be stored as uint8 in replay (for example,
+        # MiniGrid FlatObsWrapper).  Cast at the encoder boundary so collection,
+        # evaluation, and learning all feed a valid dtype to linear layers.
+        x = self.fc_representation(x.float())
         x = self.norm(x)
 
         return x

--- a/lzero/policy/muzero.py
+++ b/lzero/policy/muzero.py
@@ -104,10 +104,6 @@ class MuZeroPolicy(Policy):
         battle_mode='play_with_bot_mode',
         # (bool) Whether to monitor extra statistics in tensorboard.
         monitor_extra_statistics=True,
-        # (int) Log key MuZero matrix norms/nonzero ratios every N learner
-        # updates.  Zero disables the monitor.  This is intentionally separate
-        # from monitor_extra_statistics because it performs device reductions.
-        model_parameter_health_monitor_interval=0,
         # (int) The transition number of one ``GameSegment``.
         game_segment_length=200,
         # (bool): Indicates whether to perform an offline evaluation of the checkpoint (ckpt).
@@ -214,7 +210,7 @@ class MuZeroPolicy(Policy):
         # the current maximum priority.  This is especially useful in sparse-
         # reward environments, where the collector-side value error can be
         # nearly uniform before the first successful trajectories are learned.
-        use_max_priority_for_new_data=True,
+        use_max_priority_for_new_data=False,
         # (float) The degree of prioritization to use. A value of 0 means no prioritization,
         # while a value of 1 means full prioritization.
         priority_prob_alpha=0.6,
@@ -278,57 +274,6 @@ class MuZeroPolicy(Policy):
         """
         self.train_iter = train_iter
         self.env_step = env_step
-
-    @staticmethod
-    @torch.no_grad()
-    def _module_parameter_health(module: torch.nn.Module, name: str) -> Dict[str, float]:
-        """Return inexpensive collapse diagnostics for a model component."""
-        matrices = [parameter.detach().float() for parameter in module.parameters() if parameter.ndim >= 2]
-        if not matrices:
-            return {}
-
-        squared_l2 = sum(torch.sum(matrix * matrix).item() for matrix in matrices)
-        numel = sum(matrix.numel() for matrix in matrices)
-        nonzero = sum(torch.count_nonzero(matrix).item() for matrix in matrices)
-        stats = {
-            f'analysis/model_parameters/{name}_weight_l2': squared_l2 ** 0.5,
-            f'analysis/model_parameters/{name}_weight_nonzero_ratio': nonzero / numel,
-        }
-
-        # Effective rank is useful for the small policy/value/reward heads, but
-        # cubic SVDs on the 512-wide backbone would noticeably slow training.
-        rank_candidates = [
-            matrix.reshape(matrix.shape[0], -1) for matrix in matrices
-            if min(matrix.shape[0], matrix.numel() // matrix.shape[0]) <= 64 and matrix.numel() <= 100_000
-        ]
-        if rank_candidates:
-            matrix = max(rank_candidates, key=lambda tensor: tensor.numel())
-            singular_values = torch.linalg.svdvals(matrix)
-            singular_value_sum = singular_values.sum()
-            if singular_value_sum.item() > 0:
-                probabilities = singular_values / singular_value_sum
-                entropy = -(probabilities * probabilities.clamp_min(1e-12).log()).sum()
-                stats[f'analysis/model_parameters/{name}_effective_rank'] = torch.exp(entropy).item()
-            else:
-                stats[f'analysis/model_parameters/{name}_effective_rank'] = 0.0
-        return stats
-
-    def _model_parameter_health(self) -> Dict[str, float]:
-        model = self._learn_model
-        prediction = model.prediction_network
-        dynamics = model.dynamics_network
-        components = {
-            'representation': model.representation_network,
-            'dynamics': dynamics,
-            'prediction_common': prediction.fc_prediction_common,
-            'policy_head': prediction.fc_policy_head,
-            'value_head': prediction.fc_value_head,
-            'reward_head': dynamics.fc_reward_head,
-        }
-        stats = {}
-        for name, module in components.items():
-            stats.update(self._module_parameter_health(module, name))
-        return stats
 
     def _init_learn(self) -> None:
         """
@@ -415,7 +360,6 @@ class MuZeroPolicy(Policy):
         self.grad_norm_after = 0.
         self.dormant_ratio_encoder = 0.
         self.dormant_ratio_dynamics = 0.
-        self._model_parameter_health_update_count = 0
 
         if self._cfg.use_wandb:
             # TODO: add the model to wandb
@@ -719,14 +663,6 @@ class MuZeroPolicy(Policy):
             'analysis/grad_norm_before': self.grad_norm_before,
             'analysis/grad_norm_after': self.grad_norm_after,
         }
-
-        self._model_parameter_health_update_count += 1
-        health_interval = self._cfg.model_parameter_health_monitor_interval
-        if health_interval > 0 and (
-                self._model_parameter_health_update_count == 1
-                or self._model_parameter_health_update_count % health_interval == 0
-        ):
-            return_log_dict.update(self._model_parameter_health())
         
         # ["harmony_dynamics", "harmony_policy", "harmony_value", "harmony_reward", "harmony_entropy"]
         if self._cfg.model.harmony_balance:

--- a/lzero/policy/muzero.py
+++ b/lzero/policy/muzero.py
@@ -104,6 +104,10 @@ class MuZeroPolicy(Policy):
         battle_mode='play_with_bot_mode',
         # (bool) Whether to monitor extra statistics in tensorboard.
         monitor_extra_statistics=True,
+        # (int) Log key MuZero matrix norms/nonzero ratios every N learner
+        # updates.  Zero disables the monitor.  This is intentionally separate
+        # from monitor_extra_statistics because it performs device reductions.
+        model_parameter_health_monitor_interval=0,
         # (int) The transition number of one ``GameSegment``.
         game_segment_length=200,
         # (bool): Indicates whether to perform an offline evaluation of the checkpoint (ckpt).
@@ -206,6 +210,11 @@ class MuZeroPolicy(Policy):
         # ****** Priority ******
         # (bool) Whether to use priority when sampling training data from the buffer.
         use_priority=False,
+        # (bool) Whether newly collected transitions should enter replay with
+        # the current maximum priority.  This is especially useful in sparse-
+        # reward environments, where the collector-side value error can be
+        # nearly uniform before the first successful trajectories are learned.
+        use_max_priority_for_new_data=True,
         # (float) The degree of prioritization to use. A value of 0 means no prioritization,
         # while a value of 1 means full prioritization.
         priority_prob_alpha=0.6,
@@ -269,6 +278,57 @@ class MuZeroPolicy(Policy):
         """
         self.train_iter = train_iter
         self.env_step = env_step
+
+    @staticmethod
+    @torch.no_grad()
+    def _module_parameter_health(module: torch.nn.Module, name: str) -> Dict[str, float]:
+        """Return inexpensive collapse diagnostics for a model component."""
+        matrices = [parameter.detach().float() for parameter in module.parameters() if parameter.ndim >= 2]
+        if not matrices:
+            return {}
+
+        squared_l2 = sum(torch.sum(matrix * matrix).item() for matrix in matrices)
+        numel = sum(matrix.numel() for matrix in matrices)
+        nonzero = sum(torch.count_nonzero(matrix).item() for matrix in matrices)
+        stats = {
+            f'analysis/model_parameters/{name}_weight_l2': squared_l2 ** 0.5,
+            f'analysis/model_parameters/{name}_weight_nonzero_ratio': nonzero / numel,
+        }
+
+        # Effective rank is useful for the small policy/value/reward heads, but
+        # cubic SVDs on the 512-wide backbone would noticeably slow training.
+        rank_candidates = [
+            matrix.reshape(matrix.shape[0], -1) for matrix in matrices
+            if min(matrix.shape[0], matrix.numel() // matrix.shape[0]) <= 64 and matrix.numel() <= 100_000
+        ]
+        if rank_candidates:
+            matrix = max(rank_candidates, key=lambda tensor: tensor.numel())
+            singular_values = torch.linalg.svdvals(matrix)
+            singular_value_sum = singular_values.sum()
+            if singular_value_sum.item() > 0:
+                probabilities = singular_values / singular_value_sum
+                entropy = -(probabilities * probabilities.clamp_min(1e-12).log()).sum()
+                stats[f'analysis/model_parameters/{name}_effective_rank'] = torch.exp(entropy).item()
+            else:
+                stats[f'analysis/model_parameters/{name}_effective_rank'] = 0.0
+        return stats
+
+    def _model_parameter_health(self) -> Dict[str, float]:
+        model = self._learn_model
+        prediction = model.prediction_network
+        dynamics = model.dynamics_network
+        components = {
+            'representation': model.representation_network,
+            'dynamics': dynamics,
+            'prediction_common': prediction.fc_prediction_common,
+            'policy_head': prediction.fc_policy_head,
+            'value_head': prediction.fc_value_head,
+            'reward_head': dynamics.fc_reward_head,
+        }
+        stats = {}
+        for name, module in components.items():
+            stats.update(self._module_parameter_health(module, name))
+        return stats
 
     def _init_learn(self) -> None:
         """
@@ -355,6 +415,7 @@ class MuZeroPolicy(Policy):
         self.grad_norm_after = 0.
         self.dormant_ratio_encoder = 0.
         self.dormant_ratio_dynamics = 0.
+        self._model_parameter_health_update_count = 0
 
         if self._cfg.use_wandb:
             # TODO: add the model to wandb
@@ -658,6 +719,14 @@ class MuZeroPolicy(Policy):
             'analysis/grad_norm_before': self.grad_norm_before,
             'analysis/grad_norm_after': self.grad_norm_after,
         }
+
+        self._model_parameter_health_update_count += 1
+        health_interval = self._cfg.model_parameter_health_monitor_interval
+        if health_interval > 0 and (
+                self._model_parameter_health_update_count == 1
+                or self._model_parameter_health_update_count % health_interval == 0
+        ):
+            return_log_dict.update(self._model_parameter_health())
         
         # ["harmony_dynamics", "harmony_policy", "harmony_value", "harmony_reward", "harmony_entropy"]
         if self._cfg.model.harmony_balance:

--- a/lzero/policy/utils.py
+++ b/lzero/policy/utils.py
@@ -490,7 +490,11 @@ def prepare_obs(obs_batch_ori: np.ndarray, cfg: EasyDict, task_id = None) -> Tup
     """
     # Convert the numpy array of original observations to a PyTorch tensor and transfer it to the specified device.
     # Also, ensure the tensor is of the correct floating-point type for the model.
-    obs_batch_ori = torch.from_numpy(obs_batch_ori).to(cfg.device)
+    # Some Gymnasium environments (including MiniGrid's FlatObsWrapper) emit
+    # uint8 vector observations.  MLP/linear layers require floating-point
+    # inputs, so normalize the dtype at the policy boundary while retaining the
+    # compact replay-buffer representation.
+    obs_batch_ori = torch.from_numpy(obs_batch_ori).to(cfg.device).float()
 
     # Calculate the dimension size to slice based on the model configuration.
     # For convolutional models ('conv'), use the number of frames to stack times the number of channels.

--- a/lzero/reward_model/rnd_reward_model.py
+++ b/lzero/reward_model/rnd_reward_model.py
@@ -193,7 +193,7 @@ class RNDRewardModel(BaseRewardModel):
         elif self.input_type == 'latent_state':
             train_data = random.sample(self.train_latent_state, self.cfg.batch_size)
 
-        train_data = torch.stack(train_data).to(self.device)
+        train_data = torch.stack(train_data).to(self.device).float()
 
         if self.cfg.input_norm:
             # Note: observation normalization: transform obs to mean 0, std 1
@@ -234,22 +234,43 @@ class RNDRewardModel(BaseRewardModel):
         obs_batch_orig = data[0][0]
         target_reward = data[1][0]
         batch_size = obs_batch_orig.shape[0]
-        # reshape to (4, 2835, 6)
-        obs_batch_tmp = np.reshape(obs_batch_orig, (batch_size, self.cfg.obs_shape, 6))
-        # reshape to (24, 2835)
-        obs_batch_tmp = np.reshape(obs_batch_tmp, (batch_size * 6, self.cfg.obs_shape))
+        if not isinstance(self.cfg.obs_shape, int):
+            raise ValueError(
+                f'RNDRewardModel currently expects a flat integer obs_shape, got {self.cfg.obs_shape!r}'
+            )
+
+        # MuZero flattens [batch, sequence, observation] into [batch,
+        # sequence * observation] before the reward model sees it.  Derive the
+        # sequence length instead of assuming num_unroll_steps == 5 (six
+        # observations/targets), and fail early on inconsistent configurations.
+        flattened_obs_size = int(np.prod(obs_batch_orig.shape[1:]))
+        if flattened_obs_size % self.cfg.obs_shape != 0:
+            raise ValueError(
+                f'Flattened observation size {flattened_obs_size} is not divisible by '
+                f'configured obs_shape {self.cfg.obs_shape}.'
+            )
+        sequence_length = flattened_obs_size // self.cfg.obs_shape
+        target_sequence_length = target_reward.shape[1]
+        if sequence_length != target_sequence_length:
+            raise ValueError(
+                f'RND observation sequence length ({sequence_length}) does not match reward target sequence '
+                f'length ({target_sequence_length}). Check frame_stack_num and num_unroll_steps.'
+            )
+        obs_batch_tmp = np.reshape(obs_batch_orig, (batch_size * sequence_length, self.cfg.obs_shape))
 
         if self.input_type == 'latent_state':
             with torch.no_grad():
-                latent_state = self.representation_network(torch.from_numpy(obs_batch_tmp).to(self.device))
+                latent_state = self.representation_network(
+                    torch.from_numpy(obs_batch_tmp).to(self.device).float()
+                )
             input_data = latent_state
         elif self.input_type in ['obs', 'obs_latent_state']:
-            input_data = to_tensor(obs_batch_tmp).to(self.device)
+            input_data = to_tensor(obs_batch_tmp).to(self.device).float()
 
         # NOTE: deepcopy reward part of data is very important,
         # otherwise the reward of data in the replay buffer will be incorrectly modified.
         target_reward_augmented = copy.deepcopy(target_reward)
-        target_reward_augmented = np.reshape(target_reward_augmented, (batch_size * 6, 1))
+        target_reward_augmented = np.reshape(target_reward_augmented, (batch_size * sequence_length, 1))
 
         if self.cfg.input_norm:
             # add this line to avoid inplace operation on the original tensor.
@@ -294,24 +315,31 @@ class RNDRewardModel(BaseRewardModel):
         self.tb_logger.add_scalar('augmented_reward/reward_min', np.min(target_reward_augmented), self.estimate_cnt_rnd)
         self.tb_logger.add_scalar('augmented_reward/reward_std', np.std(target_reward_augmented), self.estimate_cnt_rnd)
 
-        # reshape to (target_reward_augmented.shape[0], 6, 1)
-        target_reward_augmented = np.reshape(target_reward_augmented, (batch_size, 6, 1))
+        target_reward_augmented = np.reshape(
+            target_reward_augmented, (batch_size, sequence_length, 1)
+        )
         data[1][0] = target_reward_augmented
         train_data_augmented = data
 
         return train_data_augmented
 
     def collect_data(self, data: list) -> None:
-        # TODO(pu): now we only collect the first 300 steps of each game segment.
-        collected_transitions = np.concatenate([game_segment.obs_segment[:300] for game_segment in data[0]], axis=0)
+        # Exclude cross-segment bootstrap padding.  The old hard-coded 300
+        # silently included padding whenever game_segment_length was smaller.
+        collected_transitions = np.concatenate(
+            [game_segment.obs_segment[:game_segment.game_segment_length] for game_segment in data[0]], axis=0
+        )
         if self.input_type == 'latent_state':
             with torch.no_grad():
                 self.train_latent_state.extend(
-                    self.representation_network(torch.from_numpy(collected_transitions).to(self.device)))
+                    self.representation_network(
+                        torch.from_numpy(collected_transitions).to(self.device).float()
+                    ).detach().cpu()
+                )
         elif self.input_type == 'obs':
-            self.train_obs.extend(to_tensor(collected_transitions).to(self.device))
+            self.train_obs.extend(to_tensor(collected_transitions))
         elif self.input_type == 'obs_latent_state':
-            self.train_obs.extend(to_tensor(collected_transitions).to(self.device))
+            self.train_obs.extend(to_tensor(collected_transitions))
 
     def clear_old_data(self) -> None:
         if self.input_type == 'latent_state':

--- a/lzero/reward_model/rnd_reward_model.py
+++ b/lzero/reward_model/rnd_reward_model.py
@@ -133,6 +133,15 @@ class RNDRewardModel(BaseRewardModel):
         # (float) The weight of intrinsic reward
         # r = intrinsic_reward_weight * r_i + r_e.
         intrinsic_reward_weight=0.01,
+        # (float or None) Final intrinsic-reward weight after linear decay.
+        # ``None`` keeps the legacy constant-weight behavior.
+        intrinsic_reward_weight_final=None,
+        # (int) Learner/RND estimate step at which linear decay starts.
+        intrinsic_reward_weight_decay_start=0,
+        # (int) Number of estimate steps used to reach the final weight.
+        # A non-positive value applies the final weight immediately at the
+        # decay start (when a final weight is configured).
+        intrinsic_reward_weight_decay_steps=0,
         # (bool) Whether to normalize extrinsic reward.
         # Normalize the reward to [0, extrinsic_reward_norm_max].
         extrinsic_reward_norm=True,
@@ -186,6 +195,24 @@ class RNDRewardModel(BaseRewardModel):
         self._running_mean_std_rnd_obs = RunningMeanStd(epsilon=1e-4)
         self.estimate_cnt_rnd = 0
         self.train_cnt_rnd = 0
+
+    def _current_intrinsic_reward_weight(self) -> float:
+        """Return the scheduled RND coefficient for the current estimate step."""
+        initial_weight = float(self.cfg.intrinsic_reward_weight)
+        final_weight = getattr(self.cfg, 'intrinsic_reward_weight_final', None)
+        if final_weight is None:
+            return initial_weight
+
+        final_weight = float(final_weight)
+        decay_start = max(0, int(getattr(self.cfg, 'intrinsic_reward_weight_decay_start', 0)))
+        decay_steps = max(0, int(getattr(self.cfg, 'intrinsic_reward_weight_decay_steps', 0)))
+        if self.estimate_cnt_rnd <= decay_start:
+            return initial_weight
+        if decay_steps == 0:
+            return final_weight
+
+        progress = min(1.0, (self.estimate_cnt_rnd - decay_start) / decay_steps)
+        return initial_weight + progress * (final_weight - initial_weight)
 
     def _train_with_data_one_step(self) -> None:
         if self.input_type in ['obs', 'obs_latent_state']:
@@ -298,11 +325,18 @@ class RNDRewardModel(BaseRewardModel):
             self.tb_logger.add_scalar('rnd_reward_model/rnd_reward_std', rnd_reward.std(), self.estimate_cnt_rnd)
 
         rnd_reward = rnd_reward.to(self.device).unsqueeze(1).cpu().numpy()
+        intrinsic_reward_weight = self._current_intrinsic_reward_weight()
+        self.tb_logger.add_scalar(
+            'rnd_reward_model/intrinsic_reward_weight', intrinsic_reward_weight, self.estimate_cnt_rnd
+        )
         if self.intrinsic_reward_type == 'add':
             if self.cfg.extrinsic_reward_norm:
-                target_reward_augmented = target_reward_augmented / self.cfg.extrinsic_reward_norm_max + rnd_reward * self.cfg.intrinsic_reward_weight
+                target_reward_augmented = (
+                    target_reward_augmented / self.cfg.extrinsic_reward_norm_max
+                    + rnd_reward * intrinsic_reward_weight
+                )
             else:
-                target_reward_augmented = target_reward_augmented + rnd_reward * self.cfg.intrinsic_reward_weight
+                target_reward_augmented = target_reward_augmented + rnd_reward * intrinsic_reward_weight
         elif self.intrinsic_reward_type == 'new':
             if self.cfg.extrinsic_reward_norm:
                 target_reward_augmented = target_reward_augmented / self.cfg.extrinsic_reward_norm_max

--- a/lzero/reward_model/tests/test_rnd_reward_schedule.py
+++ b/lzero/reward_model/tests/test_rnd_reward_schedule.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pytest
+
+from lzero.reward_model.rnd_reward_model import RNDRewardModel
+
+
+def _model(step, final_weight=0.0, decay_start=25, decay_steps=45):
+    model = RNDRewardModel.__new__(RNDRewardModel)
+    model.cfg = SimpleNamespace(
+        intrinsic_reward_weight=1 / 300,
+        intrinsic_reward_weight_final=final_weight,
+        intrinsic_reward_weight_decay_start=decay_start,
+        intrinsic_reward_weight_decay_steps=decay_steps,
+    )
+    model.estimate_cnt_rnd = step
+    return model
+
+
+@pytest.mark.parametrize(
+    'step, expected',
+    [
+        (0, 1 / 300),
+        (25, 1 / 300),
+        (47, (1 / 300) * (1 - 22 / 45)),
+        (70, 0.0),
+        (100, 0.0),
+    ],
+)
+def test_intrinsic_reward_weight_linear_decay(step, expected):
+    assert _model(step)._current_intrinsic_reward_weight() == pytest.approx(expected)
+
+
+def test_intrinsic_reward_weight_legacy_constant_behavior():
+    model = _model(step=100)
+    model.cfg.intrinsic_reward_weight_final = None
+    assert model._current_intrinsic_reward_weight() == pytest.approx(1 / 300)
+
+
+def test_intrinsic_reward_weight_zero_length_decay():
+    model = _model(step=26, final_weight=0.001, decay_steps=0)
+    assert model._current_intrinsic_reward_weight() == pytest.approx(0.001)

--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -214,7 +214,8 @@ class MuZeroCollector(ISerialCollector):
         Returns:
             - priorities (:obj:`Optional[np.ndarray]`): An array of priorities for the transitions. Returns None if priority is not used.
         """
-        if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
+        use_max_priority = getattr(self.policy_config, 'use_max_priority_for_new_data', False)
+        if self.policy_config.use_priority and not use_max_priority:
             # Calculate priorities as the L1 loss between predicted values and search values.
             # 'reduction=none' ensures the loss is calculated for each element individually.
             pred_values = torch.from_numpy(np.array(pred_values_lst[i])).to(self.policy_config.device).float().view(-1)
@@ -506,7 +507,8 @@ class MuZeroCollector(ISerialCollector):
                             completed_value_lst[env_id] += np.mean(np.array(completed_value_dict[env_id]))
                     
                     eps_steps_lst[env_id] += 1
-                    if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
+                    use_max_priority = getattr(self.policy_config, 'use_max_priority_for_new_data', False)
+                    if self.policy_config.use_priority and not use_max_priority:
                         pred_values_lst[env_id].append(pred_value_dict[env_id])
                         search_values_lst[env_id].append(value_dict[env_id])
 

--- a/lzero/worker/muzero_collector.py
+++ b/lzero/worker/muzero_collector.py
@@ -214,7 +214,7 @@ class MuZeroCollector(ISerialCollector):
         Returns:
             - priorities (:obj:`Optional[np.ndarray]`): An array of priorities for the transitions. Returns None if priority is not used.
         """
-        if self.policy_config.use_priority:
+        if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
             # Calculate priorities as the L1 loss between predicted values and search values.
             # 'reduction=none' ensures the loss is calculated for each element individually.
             pred_values = torch.from_numpy(np.array(pred_values_lst[i])).to(self.policy_config.device).float().view(-1)
@@ -223,7 +223,8 @@ class MuZeroCollector(ISerialCollector):
             # A small epsilon is added to avoid zero priorities.
             priorities = L1Loss(reduction='none')(pred_values, search_values).detach().cpu().numpy() + 1e-6
         else:
-            # If priority is not used, return None. The replay buffer will use max priority for new data.
+            # ``None`` asks the replay buffer to assign its current maximum
+            # priority.  This is also the correct fast path when PER is off.
             priorities = None
 
         return priorities
@@ -505,7 +506,7 @@ class MuZeroCollector(ISerialCollector):
                             completed_value_lst[env_id] += np.mean(np.array(completed_value_dict[env_id]))
                     
                     eps_steps_lst[env_id] += 1
-                    if self.policy_config.use_priority:
+                    if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
                         pred_values_lst[env_id].append(pred_value_dict[env_id])
                         search_values_lst[env_id].append(value_dict[env_id])
 

--- a/lzero/worker/muzero_segment_collector.py
+++ b/lzero/worker/muzero_segment_collector.py
@@ -213,7 +213,7 @@ class MuZeroSegmentCollector(ISerialCollector):
         Returns:
             - priorities (:obj:`Optional[np.ndarray]`): An array of computed priorities, or None if priority is disabled.
         """
-        if self.policy_config.use_priority:
+        if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
             # Calculate priorities as the L1 loss between predicted and search values.
             # The reduction is 'none' to get per-element losses.
             # A small epsilon (1e-6) is added to prevent zero priorities.
@@ -221,7 +221,7 @@ class MuZeroSegmentCollector(ISerialCollector):
             search_values = torch.from_numpy(np.array(search_values_lst[i])).to(self.policy_config.device).float().view(-1)
             priorities = L1Loss(reduction='none')(pred_values, search_values).detach().cpu().numpy() + 1e-6
         else:
-            # If not using priority, all new data will use the maximum priority in the replay buffer.
+            # ``None`` asks replay to assign the current maximum priority.
             priorities = None
 
         return priorities
@@ -502,7 +502,7 @@ class MuZeroSegmentCollector(ISerialCollector):
                     if self._policy.get_attribute('cfg').type in ['unizero', 'sampled_unizero']:
                         self._policy.reset(env_id=env_id, current_steps=eps_steps_lst[env_id], reset_init_data=False)
 
-                    if self.policy_config.use_priority:
+                    if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
                         pred_values_lst[env_id].append(pred_value_dict_with_env_id[env_id])
                         search_values_lst[env_id].append(value_dict_with_env_id[env_id])
                         if self.policy_config.gumbel_algo and not collect_with_pure_policy:

--- a/lzero/worker/muzero_segment_collector.py
+++ b/lzero/worker/muzero_segment_collector.py
@@ -213,7 +213,8 @@ class MuZeroSegmentCollector(ISerialCollector):
         Returns:
             - priorities (:obj:`Optional[np.ndarray]`): An array of computed priorities, or None if priority is disabled.
         """
-        if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
+        use_max_priority = getattr(self.policy_config, 'use_max_priority_for_new_data', False)
+        if self.policy_config.use_priority and not use_max_priority:
             # Calculate priorities as the L1 loss between predicted and search values.
             # The reduction is 'none' to get per-element losses.
             # A small epsilon (1e-6) is added to prevent zero priorities.
@@ -502,7 +503,8 @@ class MuZeroSegmentCollector(ISerialCollector):
                     if self._policy.get_attribute('cfg').type in ['unizero', 'sampled_unizero']:
                         self._policy.reset(env_id=env_id, current_steps=eps_steps_lst[env_id], reset_init_data=False)
 
-                    if self.policy_config.use_priority and not self.policy_config.use_max_priority_for_new_data:
+                    use_max_priority = getattr(self.policy_config, 'use_max_priority_for_new_data', False)
+                    if self.policy_config.use_priority and not use_max_priority:
                         pred_values_lst[env_id].append(pred_value_dict_with_env_id[env_id])
                         search_values_lst[env_id].append(value_dict_with_env_id[env_id])
                         if self.policy_config.gumbel_algo and not collect_with_pure_policy:

--- a/zoo/minigrid/config/minigrid_muzero_rnd_1m_optimized_config.py
+++ b/zoo/minigrid/config/minigrid_muzero_rnd_1m_optimized_config.py
@@ -1,0 +1,52 @@
+"""One-million-step optimized MuZero+SSL+RND run for KeyCorridorS3R3."""
+
+from copy import deepcopy
+
+from zoo.minigrid.config.minigrid_muzero_rnd_config import (
+    create_config as baseline_create_config,
+    main_config as baseline_main_config,
+    seed,
+)
+
+
+max_env_step = int(1e6)
+main_config = deepcopy(baseline_main_config)
+create_config = deepcopy(baseline_create_config)
+
+main_config.exp_name = (
+    'data_mz_rnd_ctree/MiniGrid-KeyCorridorS3R3-v0_muzero-rnd_'
+    'opt-v2_rnd-decay_td20_rb3e5_temp5e4_1m_seed0'
+)
+
+# A score above 0.8 means that all three deterministic evaluation layouts are
+# being solved efficiently; stop immediately once that target is reached.
+main_config.env.stop_value = 0.8
+
+# The baseline first discovers success around 250k env steps, but its fixed
+# novelty bonus remains active during evaluation planning.  Estimate count is
+# one-to-one with learner updates (~10 learner updates per 100 env steps in the
+# observed run): retain full RND through ~350k env steps and decay it to zero by
+# ~700k so the second half of training consolidates the extrinsic objective.
+main_config.reward_model.intrinsic_reward_weight_final = 0.0
+main_config.reward_model.intrinsic_reward_weight_decay_start = int(3.5e4)
+main_config.reward_model.intrinsic_reward_weight_decay_steps = int(3.5e4)
+
+# The entry schedules visit-count temperature by learner iteration.  The old
+# 5e5 threshold kept temperature at 1.0 throughout the first million env steps.
+# This schedule reaches 0.5 around 250k and the final 0.25 around 375k while RND
+# and root Dirichlet noise continue to provide exploration.
+main_config.policy.threshold_training_steps_for_final_temperature = int(5e4)
+
+# Propagate each rare terminal reward farther per update and discard the oldest
+# random failures once the buffer reaches 300k transitions.  PER still retains
+# and emphasizes surprising successful transitions within the recent window.
+main_config.policy.td_steps = 20
+main_config.policy.replay_buffer_size = int(3e5)
+
+
+if __name__ == '__main__':
+    from lzero.entry import train_muzero_with_reward_model
+
+    train_muzero_with_reward_model(
+        [main_config, create_config], seed=seed, max_env_step=max_env_step
+    )

--- a/zoo/minigrid/config/minigrid_muzero_rnd_config.py
+++ b/zoo/minigrid/config/minigrid_muzero_rnd_config.py
@@ -111,7 +111,6 @@ minigrid_muzero_rnd_config = dict(
         # configure_optimizers().
         optim_type='AdamW',
         weight_decay=1e-4,
-        model_parameter_health_monitor_interval=100,
         piecewise_decay_lr_scheduler=False,
         learning_rate=0.003,
         ssl_loss_weight=2,  # NOTE: default is 0.

--- a/zoo/minigrid/config/minigrid_muzero_rnd_config.py
+++ b/zoo/minigrid/config/minigrid_muzero_rnd_config.py
@@ -1,9 +1,11 @@
 from easydict import EasyDict
 
-# The typical MiniGrid env id: {'MiniGrid-Empty-8x8-v0', 'MiniGrid-FourRooms-v0', 'MiniGrid-DoorKey-8x8-v0','MiniGrid-DoorKey-16x16-v0'},
+# This is the benchmark environment used by the MiniGrid intrinsic-exploration
+# curve in the LightZero paper/README.
 # please refer to https://github.com/Farama-Foundation/MiniGrid for details.
-env_id = 'MiniGrid-Empty-8x8-v0'
-max_env_step = int(1e6)
+env_id = 'MiniGrid-KeyCorridorS3R3-v0'
+max_episode_steps = 300
+max_env_step = int(2e6)
 
 # ==============================================================
 # begin of the most frequently changed config specified by the user
@@ -21,7 +23,9 @@ td_steps = 5
 # key exploration related config
 policy_entropy_weight = 0.
 threshold_training_steps_for_final_temperature = int(5e5)
-eps_greedy_exploration_in_collect = True
+# Keep RND as the only additional exploration mechanism.  Enabling this would
+# evaluate RND + epsilon-greedy rather than the paper's IntrinsicExploration arm.
+eps_greedy_exploration_in_collect = False
 input_type = 'obs'  # options=['obs', 'latent_state', 'obs_latent_state']
 target_model_for_intrinsic_reward_update_type = 'assign'  # 'assign' or 'momentum'
 
@@ -32,10 +36,12 @@ target_model_for_intrinsic_reward_update_type = 'assign'  # 'assign' or 'momentu
 minigrid_muzero_rnd_config = dict(
     exp_name=f'data_mz_rnd_ctree/{env_id}_muzero-rnd_ns{num_simulations}_upc{update_per_collect}_rer{reanalyze_ratio}'
              f'_collect-eps-{eps_greedy_exploration_in_collect}_temp-final-steps-{threshold_training_steps_for_final_temperature}_pelw{policy_entropy_weight}'
-             f'_rnd-rew-{input_type}-{target_model_for_intrinsic_reward_update_type}_seed{seed}',
+             f'_rnd-rew-{input_type}-{target_model_for_intrinsic_reward_update_type}'
+             f'_opt-AdamW_per-max_2m_seed{seed}',
     env=dict(
         stop_value=int(1e6),
         env_id=env_id,
+        max_step=max_episode_steps,
         continuous=False,
         manually_discretization=False,
         collector_env_num=collector_env_num,
@@ -50,7 +56,7 @@ minigrid_muzero_rnd_config = dict(
         # intrinsic_reward_weight means the relative weight of RND intrinsic_reward.
         # Specifically for sparse reward env MiniGrid, in this env, if we reach goal, the agent gets reward ~1, otherwise 0.
         # We could set the intrinsic_reward_weight approximately equal to the inverse of max_episode_steps.Please refer to rnd_reward_model for details.
-        intrinsic_reward_weight=0.003,  # 1/300
+        intrinsic_reward_weight=1 / max_episode_steps,
         obs_shape=2835,
         latent_state_dim=512,
         hidden_size_list=[256, 256],
@@ -58,7 +64,10 @@ minigrid_muzero_rnd_config = dict(
         weight_decay=1e-4,
         batch_size=batch_size,
         update_per_collect=200,
-        rnd_buffer_size=int(1e6),
+        # Keeping one million 2835-D observations on the accelerator can consume
+        # several GB.  The reward model stores this replay on CPU; 100k recent
+        # observations are sufficient for the predictor's random minibatches.
+        rnd_buffer_size=int(1e5),
         input_norm=True,
         input_norm_clamp_max=5,
         input_norm_clamp_min=-5,
@@ -96,7 +105,13 @@ minigrid_muzero_rnd_config = dict(
         game_segment_length=300,
         update_per_collect=update_per_collect,
         batch_size=batch_size,
-        optim_type='Adam',
+        # Adam's coupled L2 regularization can erase zero-initialized MuZero
+        # heads before gradients reach their upstream MLPs.  AdamW applies a
+        # small decoupled shrinkage and excludes BN/bias parameters through
+        # configure_optimizers().
+        optim_type='AdamW',
+        weight_decay=1e-4,
+        model_parameter_health_monitor_interval=100,
         piecewise_decay_lr_scheduler=False,
         learning_rate=0.003,
         ssl_loss_weight=2,  # NOTE: default is 0.
@@ -104,7 +119,14 @@ minigrid_muzero_rnd_config = dict(
         num_simulations=num_simulations,
         reanalyze_ratio=reanalyze_ratio,
         n_episode=n_episode,
-        eval_freq=int(2e2),
+        # Preserve rare successful KeyCorridor trajectories: these were the
+        # paper-time settings, but later policy defaults disabled PER and the
+        # max-priority insertion switch disappeared from the collector path.
+        use_priority=True,
+        use_max_priority_for_new_data=True,
+        priority_prob_alpha=0.6,
+        priority_prob_beta=0.4,
+        eval_freq=int(1e3),
         replay_buffer_size=int(1e6),  # the size/capacity of replay_buffer, in the terms of transitions.
         collector_env_num=collector_env_num,
         evaluator_env_num=evaluator_env_num,

--- a/zoo/minigrid/envs/minigrid_lightzero_env.py
+++ b/zoo/minigrid/envs/minigrid_lightzero_env.py
@@ -85,10 +85,13 @@ class MiniGridEnvLightZero(MiniGridEnv):
                 self._env = gym.make(self._env_id, render_mode="rgb_array")
             else:
                 self._env = gym.make(self._env_id)
-            # NOTE: customize the max step of the env
-            self._env.max_steps = self._max_step
+            # MiniGrid owns ``max_steps`` on the base environment.  Assigning it
+            # to a Gymnasium wrapper only creates/shadows a wrapper attribute in
+            # recent Gymnasium releases and leaves the real episode horizon
+            # unchanged.
+            self._env.unwrapped.max_steps = self._max_step
 
-            if self._env_id in ['MiniGrid-AKTDT-13x13-v0' or 'MiniGrid-AKTDT-13x13-1-v0']:
+            if self._env_id in ['MiniGrid-AKTDT-13x13-v0', 'MiniGrid-AKTDT-13x13-1-v0']:
                 # customize the agent field of view size, note this must be an odd number
                 # This also related to the observation space, see gym_minigrid.wrappers for more details
                 self._env = ViewSizeWrapper(self._env, agent_view_size=5)
@@ -102,7 +105,10 @@ class MiniGridEnvLightZero(MiniGridEnv):
                 self._env = ObsPlusPrevActRewWrapper(self._env)
             self._init_flag = True
         if self._flat_obs:
-            self._observation_space = gym.spaces.Box(0, 1, shape=(2835, ))
+            # FlatObsWrapper currently emits uint8 values in [0, 255] (the
+            # encoded image itself contains values greater than one).  Reuse
+            # its space instead of advertising the old, invalid [0, 1] box.
+            self._observation_space = self._env.observation_space
         else:
             self._observation_space = self._env.observation_space
             # to be compatible with subprocess env manager
@@ -111,8 +117,11 @@ class MiniGridEnvLightZero(MiniGridEnv):
             else:
                 self._observation_space.dtype = np.dtype('float32')
         self._action_space = self._env.action_space
+        # Gymnasium>=1.0 no longer forwards arbitrary attributes through
+        # wrappers, so reward_range must be read from the base environment.
+        reward_range = self._env.unwrapped.reward_range
         self._reward_space = gym.spaces.Box(
-            low=self._env.reward_range[0], high=self._env.reward_range[1], shape=(1, ), dtype=np.float32
+            low=reward_range[0], high=reward_range[1], shape=(1, ), dtype=np.float32
         )
         if hasattr(self, '_seed') and hasattr(self, '_dynamic_seed') and self._dynamic_seed:
             np_seed = 100 * np.random.randint(1, 1000)
@@ -196,7 +205,7 @@ class MiniGridEnvLightZero(MiniGridEnv):
                 print(f'save episode {self._save_replay_count} in {self._replay_path_gif}!')
                 self._save_replay_count += 1
         obs = to_ndarray(obs)
-        rew = to_ndarray(rew)  # wrapped to be transferred to an array with shape (1,)
+        rew = to_ndarray([rew], dtype=np.float32)
 
         action_mask = np.ones(self.action_space.n, 'int8')
         self._timestep += 1

--- a/zoo/minigrid/tests/test_minigrid_muzero_rnd.py
+++ b/zoo/minigrid/tests/test_minigrid_muzero_rnd.py
@@ -1,0 +1,50 @@
+import numpy as np
+from easydict import EasyDict
+
+from zoo.minigrid.config.minigrid_muzero_rnd_1m_optimized_config import (
+    main_config as optimized_config,
+    max_env_step as optimized_max_env_step,
+)
+from zoo.minigrid.config.minigrid_muzero_rnd_config import (
+    main_config as baseline_config,
+    max_env_step as baseline_max_env_step,
+)
+from zoo.minigrid.envs.minigrid_lightzero_env import MiniGridEnvLightZero
+
+
+def test_keycorridor_rnd_configs():
+    assert baseline_config.env.env_id == 'MiniGrid-KeyCorridorS3R3-v0'
+    assert baseline_config.env.max_step == 300
+    assert baseline_config.policy.use_priority is True
+    assert baseline_config.policy.use_max_priority_for_new_data is True
+    assert baseline_max_env_step == int(2e6)
+
+    assert optimized_max_env_step == int(1e6)
+    assert optimized_config.policy.td_steps == 20
+    assert optimized_config.policy.replay_buffer_size == int(3e5)
+    assert optimized_config.reward_model.intrinsic_reward_weight_final == 0.0
+
+
+def test_flat_observation_space_and_episode_horizon():
+    env = MiniGridEnvLightZero(
+        EasyDict(
+            env_id='MiniGrid-KeyCorridorS3R3-v0',
+            flat_obs=True,
+            max_step=7,
+            save_replay_gif=False,
+            replay_path_gif=None,
+        )
+    )
+    try:
+        env.seed(0, dynamic_seed=False)
+        obs = env.reset()
+
+        assert env._env.unwrapped.max_steps == 7
+        assert env.observation_space.contains(obs['observation'])
+        assert obs['observation'].dtype == np.uint8
+
+        timestep = env.step(np.asarray([0], dtype=np.int64))
+        assert timestep.reward.shape == (1, )
+        assert timestep.reward.dtype == np.float32
+    finally:
+        env.close()


### PR DESCRIPTION
## Summary

- fix the MiniGrid/Gymnasium interface: apply the real episode horizon on the unwrapped environment, expose the actual FlatObs space, preserve reward shape/dtype, and handle uint8 vectors at model boundaries
- fix the MuZero RND pipeline: train all supported input modes, derive sequence length instead of hard-coding six observations, keep the RND replay on CPU, and exclude segment padding
- restore an opt-in max-priority insertion path for sparse-reward PER while preserving legacy behavior by default
- update the provided config to target `MiniGrid-KeyCorridorS3R3-v0` with the intended MuZero+SSL+RND setup, and add a separate 1M-step config with temperature/RND annealing

## Reproduction status

This work was prompted by a community report that the checked-in config trained on Empty/DoorKey but did not reproduce the KeyCorridorS3R3 curve.

With the repaired 2M baseline, learning is no longer stalled: at 1.158M env steps, the latest collector reward was 0.661 (recent-10 mean 0.604, peak 0.832). Evaluation remained around 0.318 because only one of the three deterministic evaluation layouts was solved. The run also showed that the original temperature threshold was expressed in learner iterations and therefore kept collection temperature at 1.0 throughout this window. RND predictor error fell substantially, while batch-normalized novelty remained non-zero.

The added 1M config addresses those observations by lowering the temperature threshold, linearly annealing the intrinsic-reward coefficient to zero, using `td_steps=20`, and limiting replay to 300k recent transitions. Full performance validation of that config is still pending GPU availability; this PR does not claim that the paper's ~0.8 score has already been reproduced.

## Tests

- `17 passed`: RND schedule, observation preparation, MLP representation, KeyCorridor config, FlatObs space, horizon, and reward shape/dtype
- end-to-end CPU smoke test: real KeyCorridor environment + CTree + RND + PER + AdamW, including learner updates
