### PR TITLE
fix(entry): pass the required logger to log_module_trainable_status / log_param_statistics

### DIFF
--- a/lzero/entry/train_unizero_multitask_balance_segment_ddp.py
+++ b/lzero/entry/train_unizero_multitask_balance_segment_ddp.py
@@ -117,10 +117,10 @@ class CurriculumController:
                 if is_entering_stage1:
                     logging.info("[Curriculum] Entering Stage 1. Freezing non-LoRA parameters in ViT Encoder.")
                     freeze_non_lora_parameters(vit_encoder, freeze=True, verbose=True)
-                log_module_trainable_status(vit_encoder, "ViT Encoder")
+                log_module_trainable_status(vit_encoder, "ViT Encoder", logging.getLogger())
             else:
                 logging.info("[Curriculum] Skipping curriculum stage update for ViT Encoder as per configuration.")
-                log_module_trainable_status(vit_encoder, "ViT Encoder (Curriculum Not Applied)")
+                log_module_trainable_status(vit_encoder, "ViT Encoder (Curriculum Not Applied)", logging.getLogger())
 
             # 2. Always apply to Transformer Decoder
             logging.info(f"[Curriculum] Applying curriculum stage {self.stage} to Transformer Backbone.")
@@ -128,7 +128,7 @@ class CurriculumController:
             if is_entering_stage1:
                 logging.info("[Curriculum] Entering Stage 1. Freezing non-LoRA parameters in Transformer Backbone.")
                 freeze_non_lora_parameters(transformer_backbone, freeze=True, verbose=True)
-            log_module_trainable_status(transformer_backbone, "Transformer Backbone")
+            log_module_trainable_status(transformer_backbone, "Transformer Backbone", logging.getLogger())
 
             logging.info(
                 f'[Curriculum] Switched to stage {self.stage} '
@@ -139,7 +139,7 @@ class CurriculumController:
             updated_params = sum(p.requires_grad for p in self.policy._learn_model.world_model.parameters())
             total_params = sum(1 for _ in self.policy._learn_model.world_model.parameters())
             logging.info(f'{updated_params}/{total_params} parameters in the world model will be optimized.')
-            log_param_statistics(self.policy._learn_model.world_model)
+            log_param_statistics(self.policy._learn_model.world_model, logging.getLogger())
 
             self.last_solved_count = solved_count
             self.last_switch_iter = train_iter


### PR DESCRIPTION
### Problem

`CurriculumController.step()` in `lzero/entry/train_unizero_multitask_balance_segment_ddp.py`
raises `TypeError` the first time a curriculum stage switch happens, so the balanced-segment
multitask UniZero DDP entry crashes exactly at the moment the curriculum is supposed to advance.

Both logging helpers it calls take a mandatory `logger`:

```python
# lzero/entry/utils.py:850
def log_module_trainable_status(
    module: nn.Module,
    module_name: str,
    logger: logging.Logger
) -> None:

# lzero/entry/utils.py:890
def log_param_statistics(model: nn.Module, logger: logging.Logger) -> None:
```

but all four call sites omit it:

```python
# train_unizero_multitask_balance_segment_ddp.py
120:                log_module_trainable_status(vit_encoder, "ViT Encoder")
123:                log_module_trainable_status(vit_encoder, "ViT Encoder (Curriculum Not Applied)")
131:            log_module_trainable_status(transformer_backbone, "Transformer Backbone")
142:            log_param_statistics(self.policy._learn_model.world_model)
```

The helpers use the argument immediately and unconditionally (`logger.info(...)`), so there is
no default to fall back on.

### Fix

Pass `logging.getLogger()`, which is exactly what `lzero/entry/utils.py`'s own reference calls
use for this function:

```python
# lzero/entry/utils.py:1035/:1040/:1045
log_module_trainable_status(model, "DummyModel", logging.getLogger())
```

The file already does `from ditk import logging` (L18) and logs through the root logger
everywhere else in this method (`logging.info(...)` at L115/118/122/126/129/133/141), so
`logging.getLogger()` routes these lines to the same place as their surrounding messages —
no new logger, no config change. `logging.getLogger()` is the established idiom in this repo
(`lzero/agent/*.py` all use it).

### Verification

Signature mismatch, so no training run is needed. I extracted both helper signatures from `main`
(`9ccf29b`) by AST and replayed the call shapes through `inspect.Signature.bind`:

```
   TypeError call site :120/:123/:131  log_module_trainable_status(m, name)     (module, module_name, logger)
              -> missing a required argument: 'logger'
   OK        sibling   :1035           log_module_trainable_status(m, n, lg)    (module, module_name, logger)
   TypeError call site :142            log_param_statistics(model)              (model, logger)
              -> missing a required argument: 'logger'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
