### PR TITLE
fix(model): effective-rank and dormant-ratio logging call sites raise TypeError

### DIFF
--- a/lzero/model/unizero_world_models/world_model.py
+++ b/lzero/model/unizero_world_models/world_model.py
@@ -10,8 +10,8 @@ import torch.nn.functional as F
 from einops import rearrange
 from lzero.model.common import SimNorm
 from lzero.model.utils import (calculate_dormant_ratio,
-                               compute_average_weight_magnitude,
-                               compute_effective_rank)
+                               calculate_effective_rank,
+                               compute_average_weight_magnitude)
 from torch.distributions import (Categorical, Independent, Normal,
                                  TanhTransform, TransformedDistribution)
 
@@ -2522,11 +2522,11 @@ class WorldModel(
             # The 'representation_layer_name' argument specifies the target layer within the model's named modules.
             
             # Effective rank for the final linear layer of the encoder.
-            e_rank_last_linear = compute_effective_rank(
+            e_rank_last_linear = calculate_effective_rank(
                 self.tokenizer.encoder, inputs, representation_layer_name="last_linear"
             )
             # Effective rank for the SimNorm layer of the encoder.
-            e_rank_sim_norm = compute_effective_rank(
+            e_rank_sim_norm = calculate_effective_rank(
                 self.tokenizer.encoder, inputs, representation_layer_name="sim_norm"
             )
 

--- a/lzero/policy/muzero.py
+++ b/lzero/policy/muzero.py
@@ -431,7 +431,7 @@ class MuZeroPolicy(Policy):
         # calculate dormant ratio of encoder
         if self._cfg.calculate_dormant_ratio:
             self.dormant_ratio_encoder = calculate_dormant_ratio(self._learn_model.representation_network, obs_batch.detach(),
-                                                           percentage=self._cfg.dormant_threshold)
+                                                           dormant_threshold=self._cfg.dormant_threshold)
         # calculate L2 norm of latent state
         latent_state_l2_norms = torch.norm(latent_state.view(latent_state.shape[0], -1), p=2, dim=1).mean()
         # ========= logging for analysis ===============
@@ -502,7 +502,7 @@ class MuZeroPolicy(Policy):
                 state_action_encoding = torch.cat((latent_state, action_encoding), dim=1)
                 self.dormant_ratio_dynamics = calculate_dormant_ratio(self._learn_model.dynamics_network,
                                                                 state_action_encoding.detach(),
-                                                                percentage=self._cfg.dormant_threshold)
+                                                                dormant_threshold=self._cfg.dormant_threshold)
             # ========= logging for analysis ===============
 
             # transform the scaled value or its categorical representation to its original value,


### PR DESCRIPTION
Two call sites in the "logging for analysis" path raise `TypeError` the moment the metric is enabled. Both are single-token mismatches against helpers that the sibling file already calls correctly.

## 1. `world_model.py` calls the wrong `*_effective_rank`

`lzero/model/utils.py` has two similarly named helpers:

```python
def compute_effective_rank(singular_values: np.ndarray) -> float:            # :38
def calculate_effective_rank(model, inputs, representation_layer_name) -> float:   # :83
```

`world_model.py` imports the first one and calls it with the second one's arguments:

```python
# lzero/model/unizero_world_models/world_model.py:2525
e_rank_last_linear = compute_effective_rank(
    self.tokenizer.encoder, inputs, representation_layer_name="last_linear"
)
```

`world_model_multitask.py:1878` — the sibling implementation of the same block — already does it right:

```python
e_rank_last_linear = calculate_effective_rank(
    self.tokenizer.encoder[encoder_index], inputs, representation_layer_name="last_linear")
```

So this changes the import and the two call sites to `calculate_effective_rank`. `compute_effective_rank` is not used anywhere else in `world_model.py`, and is still used internally by `calculate_effective_rank` (`utils.py:133`).

## 2. `muzero.py` passes `percentage=` to `calculate_dormant_ratio`

```python
def calculate_dormant_ratio(model, inputs, dormant_threshold=1e-2, target_modules=...)   # utils.py:160
```

`muzero.py:434` and `:505` pass `percentage=self._cfg.dormant_threshold`. The config key is already called `dormant_threshold`; only the keyword is stale. `world_model.py:2507` and `world_model_multitask.py:1869` both use `dormant_threshold=`.

This is gated on `if self._cfg.calculate_dormant_ratio:` (default `False`), which is why it has stayed unnoticed — but turning that analysis flag on crashes the learn step immediately.

## Verification

`lzero/model/utils.py` was loaded verbatim via `importlib` (not through the `lzero` package, so no `ditk` needed) and both call sites were replayed against a small `nn.Module` on CPU:

```
compute_effective_rank   (singular_values: numpy.ndarray) -> float
calculate_effective_rank (model, inputs, representation_layer_name: str) -> float
calculate_dormant_ratio  (model, inputs, dormant_threshold: float = 0.01, target_modules=...) -> Dict[str, float]

=== world_model.py:2525 — effective rank of a named layer ===
  compute_effective_rank  (on main): TypeError: compute_effective_rank() got an unexpected keyword argument 'representation_layer_name'
  calculate_effective_rank (patched): -> 7.2696

=== muzero.py:433 — dormant ratio ===
  percentage=          (on main): TypeError: calculate_dormant_ratio() got an unexpected keyword argument 'percentage'
  dormant_threshold=  (patched): -> global=52.3438
```

Both patched calls return a real number rather than merely binding, so the helpers do run end to end (forward hook fires, SVD computed).

No functional change anywhere else; `compute_average_weight_magnitude` and the surrounding logging are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
